### PR TITLE
Trim leading/trailing whitespace on request params that arrive as strings

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -75,6 +75,13 @@ function initServer () {
     req.query = _.extend(req.query || {}, req.body || {})
     next()
   })
+  // Trim trailing/leading whitespace from string param values;  
+  .use((req, res, next) => {
+    Object.keys(req.query).map(param=>{
+      req.query[param] = (typeof req.query[param] == 'string' || req.query[param] instanceof String) ? req.query[param].trim() : req.query[param];
+    });
+    next();
+  })
   // for demos and preview maps in providers
   .set('view engine', 'ejs')
   .use(express.static(path.join(__dirname, '/public')))

--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,7 @@ const Controller = require('./controllers')
 const Model = require('./models')
 const DatasetController = require('./controllers/dataset')
 const Dataset = require('./models/dataset')
+const middleware = require('./middleware')
 const Events = require('events')
 const Util = require('util')
 const path = require('path')
@@ -74,14 +75,8 @@ function initServer () {
     // request parameters can come from query url or POST body
     req.query = _.extend(req.query || {}, req.body || {})
     next()
-  })
-  // Trim trailing/leading whitespace from string param values;  
-  .use((req, res, next) => {
-    Object.keys(req.query).map(param=>{
-      req.query[param] = (typeof req.query[param] == 'string' || req.query[param] instanceof String) ? req.query[param].trim() : req.query[param];
-    });
-    next();
-  })
+  }) 
+  .use(middleware.paramTrim)
   // for demos and preview maps in providers
   .set('view engine', 'ejs')
   .use(express.static(path.join(__dirname, '/public')))

--- a/src/middleware/index.js
+++ b/src/middleware/index.js
@@ -1,0 +1,17 @@
+/**
+ * Middleware to trim whitespace from incoming string parameters
+ * @param {*} req 
+ * @param {*} res 
+ * @param {*} next 
+ */
+function paramTrim(req, res, next) {
+  Object.keys(req.query).map(param=>{
+    req.query[param] = (typeof req.query[param] == 'string' || req.query[param] instanceof String) 
+        ? req.query[param].trim() : req.query[param]
+    })
+  next()
+}
+
+module.exports = {
+  paramTrim
+}

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -11,7 +11,7 @@ describe('Index tests for registering providers', function () {
       koop.register(provider)
       const routeCount = (koop.server._router.stack.length)
       // TODO make this test less brittle
-      routeCount.should.equal(37)
+      routeCount.should.equal(38)
     })
   })
 })

--- a/test/middleware-test.js
+++ b/test/middleware-test.js
@@ -1,0 +1,21 @@
+const middleware = require('../src/middleware');
+const should = require('should') // eslint-disable-line
+
+describe('Middleware tests', function () {
+  describe('paramsTrim function', function () {
+    
+    it('should trim leading and trail white space from body params', function () {
+      const req = {query: { param1: ' needs-a-trim '} };
+      middleware.paramTrim(req, {}, function(){});
+      req.query.param1.should.equal('needs-a-trim')
+    })
+
+    it('should leave non-string type intact', function () {
+      const req = {query: { param1: 1} };
+      middleware.paramTrim(req, {}, function(){});
+      req.query.param1.should.equal(1)
+    })
+  })
+})
+
+


### PR DESCRIPTION
ArcGIS Pro adds preceding whitespace to the `orderByFields` parameter when adding a Koop service, which causes a parse error.  This pull request prevents the parse error by trimming request params that are of type `String`.