### PR TITLE
Route helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 ### Added
 * helper module and function to create route paths with decoration based on passed options
-* Insert the provider-specifc route fragment into the route path (rather then simple prefixing), by replacing occurence of '$provider$' substring
+* Option to insert the provider-specifc route fragments into the route path (rather then simple prefixing), by replacing occurence of '$namespace$' and '$providerParams$' substring
 
 ## [3.5.5] - 2018-04-11
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+Unreleased
+### Added
+* Insert the provider-specifc route fragment into the route path (rather then simple prefixing), by replacing occurence of '$provider$' substring
+
 ## [3.5.5] - 2018-04-11
 ### Fixed
 * replace truthy operator

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-Unreleased
+## Unreleased
 ### Added
+* helper module and function to create route paths with decoration based on passed options
 * Insert the provider-specifc route fragment into the route path (rather then simple prefixing), by replacing occurence of '$provider$' substring
 
 ## [3.5.5] - 2018-04-11

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "koop-cache-memory": "^1.0.2",
     "koop-localfs": "^1.1.1",
     "koop-output-geoservices": "^1.0.0",
-    "lodash": "^4.17.4"
+    "lodash": "^4.17.10"
   },
   "devDependencies": {
     "buble": "^0.19.0",

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -10,7 +10,7 @@ function composeRouteString(routePath, namespace, opts) {
   let options = opts || {}
   let routeFragment
 
-  if(options.skipDecoration) return path.posix.join('/', routePath)
+  if(options.absolutePath) return path.posix.join('/', routePath)
   // Build route fragment
   if (options.hosts) {
     routeFragment = path.posix.join(namespace, ':host', ':id')

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -23,6 +23,8 @@ function composeRouteString(routePath, namespace, opts) {
     return path.posix.join('/', routePath.replace('$namespace$', namespace).replace('$providerParams$', paramFragment))
   } else if (routePath.includes('$namespace$')) {
     return path.posix.join('/', routePath.replace('$namespace$', path.posix.join(namespace, paramFragment)))
+  } else if (routePath.includes('$providerParams$')) {
+    return path.posix.join('/', namespace, routePath.replace('$providerParams$', paramFragment))
   } else {
     return path.posix.join('/', namespace, paramFragment, routePath)
   }

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -2,27 +2,29 @@ const path = require('path')
 
 /**
  * Compose route string based on inputs and options
- * @param {string} namespace - namespace for the route
  * @param {string} routePath - initial route pathfragment
+ * @param {string} namespace - namespace for the route
  * @param {object} options - options object with decoration flags
  */
 function composeRouteString(routePath, namespace, opts) {
   let options = opts || {}
-  let routeFragment
+  let modifiedPath
+  let paramFragment = ''
 
+  // No compostion needed if flagged as an absolute route
   if(options.absolutePath) return path.posix.join('/', routePath)
-  // Build route fragment
-  if (options.hosts) {
-    routeFragment = path.posix.join(namespace, ':host', ':id')
-  } else if (options.disableIdParam) {
-    routeFragment = path.posix.join(namespace)
-  } else {
-    routeFragment = path.posix.join(namespace, ':id')
-  }
 
-  // routeFragment should replace the $providers$ substring if present in routePath, otherwise add as a prefix
-  if (routePath.includes('$provider$')) return path.posix.join('/', routePath.replace('$provider$', routeFragment))
-  return path.posix.join('/', routeFragment, routePath)
-  
+  // Build parameterized route fragment based on provider options
+  if (options.hosts) paramFragment = path.posix.join(':host', ':id')
+  else if (!options.disableIdParam) paramFragment = path.posix.join(':id')
+
+  // Replace placehold substrings if present, fallback to namespace/:host/:id
+  if (routePath.includes('$namespace$') && routePath.includes('$providerParams$')) {
+    return path.posix.join('/', routePath.replace('$namespace$', namespace).replace('$providerParams$', paramFragment))
+  } else if (routePath.includes('$namespace$')) {
+    return path.posix.join('/', routePath.replace('$namespace$', path.posix.join(namespace, paramFragment)))
+  } else {
+    return path.posix.join('/', namespace, paramFragment, routePath)
+  }
 }
 module.exports = { composeRouteString }

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -4,15 +4,17 @@ const path = require('path')
  * Compose route string based on inputs and options
  * @param {string} namespace - namespace for the route
  * @param {string} routePath - initial route pathfragment
- * @param {boolean} hosts - flag determining inclusion of :host in route
- * @param {boolean} disableIdParam - flag determining omission of :id in route (when hosts=false)
+ * @param {object} options - options object with decoration flags
  */
-function composeRouteString(namespace, routePath, hosts = false, disableIdParam = false) {
+function composeRouteString(routePath, namespace, opts) {
+  let options = opts || {}
   let routeFragment
+
+  if(options.skipDecoration) return path.posix.join('/', routePath)
   // Build route fragment
-  if (hosts) {
+  if (options.hosts) {
     routeFragment = path.posix.join(namespace, ':host', ':id')
-  } else if (disableIdParam) {
+  } else if (options.disableIdParam) {
     routeFragment = path.posix.join(namespace)
   } else {
     routeFragment = path.posix.join(namespace, ':id')

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -10,6 +10,8 @@ function composeRouteString(routePath, namespace, opts) {
   let options = opts || {}
   let modifiedPath
   let paramFragment = ''
+  const paramsPlaceholder = '$providerParams'
+  const namespacePlaceholder = '$namespace'
 
   // No compostion needed if flagged as an absolute route
   if(options.absolutePath) return path.posix.join('/', routePath)
@@ -19,12 +21,12 @@ function composeRouteString(routePath, namespace, opts) {
   else if (!options.disableIdParam) paramFragment = path.posix.join(':id')
 
   // Replace placehold substrings if present, fallback to namespace/:host/:id
-  if (routePath.includes('$namespace$') && routePath.includes('$providerParams$')) {
-    return path.posix.join('/', routePath.replace('$namespace$', namespace).replace('$providerParams$', paramFragment))
-  } else if (routePath.includes('$namespace$')) {
-    return path.posix.join('/', routePath.replace('$namespace$', path.posix.join(namespace, paramFragment)))
-  } else if (routePath.includes('$providerParams$')) {
-    return path.posix.join('/', namespace, routePath.replace('$providerParams$', paramFragment))
+  if (routePath.includes(namespacePlaceholder) && routePath.includes(paramsPlaceholder)) {
+    return path.posix.join('/', routePath.replace(namespacePlaceholder, namespace).replace(paramsPlaceholder, paramFragment))
+  } else if (routePath.includes(namespacePlaceholder)) {
+    return path.posix.join('/', routePath.replace(namespacePlaceholder, path.posix.join(namespace, paramFragment)))
+  } else if (routePath.includes(paramsPlaceholder)) {
+    return path.posix.join('/', namespace, routePath.replace(paramsPlaceholder, paramFragment))
   } else {
     return path.posix.join('/', namespace, paramFragment, routePath)
   }

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -1,0 +1,26 @@
+const path = require('path')
+
+/**
+ * Compose route string based on inputs and options
+ * @param {string} namespace - namespace for the route
+ * @param {string} routePath - initial route pathfragment
+ * @param {boolean} hosts - flag determining inclusion of :host in route
+ * @param {boolean} disableIdParam - flag determining omission of :id in route (when hosts=false)
+ */
+function composeRouteString(namespace, routePath, hosts = false, disableIdParam = false) {
+  let routeFragment
+  // Build route fragment
+  if (hosts) {
+    routeFragment = path.posix.join(namespace, ':host', ':id')
+  } else if (disableIdParam) {
+    routeFragment = path.posix.join(namespace)
+  } else {
+    routeFragment = path.posix.join(namespace, ':id')
+  }
+
+  // routeFragment should replace the $providers$ substring if present in routePath, otherwise add as a prefix
+  if (routePath.includes('$provider$')) return path.posix.join('/', routePath.replace('$provider$', routeFragment))
+  return path.posix.join('/', routeFragment, routePath)
+  
+}
+module.exports = { composeRouteString }

--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,7 @@ const Controller = require('./controllers')
 const Model = require('./models')
 const DatasetController = require('./controllers/dataset')
 const Dataset = require('./models/dataset')
+const helpers = require('./helpers')
 const middleware = require('./middleware')
 const Events = require('events')
 const Util = require('util')
@@ -185,14 +186,7 @@ function bindPluginOverrides (provider, controller, server, pluginRoutes) {
   const name = provider.namespace || provider.plugin_name || provider.name
   const namespace = name.replace(/\s/g, '').toLowerCase()
   pluginRoutes.forEach(route => {
-    let fullRoute
-    if (provider.hosts) {
-      fullRoute = path.posix.join('/', namespace, ':host', ':id', route.path)
-    } else if (provider.disableIdParam) {
-      fullRoute = path.posix.join('/', namespace, route.path)
-    } else {
-      fullRoute = path.posix.join('/', namespace, ':id', route.path)
-    }
+    let fullRoute = helpers.composeRouteString(namespace, route.path, provider.hosts, provider.disableIdParam)
     route.methods.forEach(method => {
       try {
         console.log(`provider=${provider.name} fullRoute:${fullRoute}`)

--- a/src/index.js
+++ b/src/index.js
@@ -186,7 +186,7 @@ function bindPluginOverrides (provider, controller, server, pluginRoutes) {
   const name = provider.namespace || provider.plugin_name || provider.name
   const namespace = name.replace(/\s/g, '').toLowerCase()
   pluginRoutes.forEach(route => {
-    let fullRoute = helpers.composeRouteString(namespace, route.path, provider.hosts, provider.disableIdParam)
+    let fullRoute = helpers.composeRouteString(namespace, route.path, {hosts: provider.hosts, disableIdParam: provider.disableIdParam, skipDecoration: route.skipDecoration})
     route.methods.forEach(method => {
       try {
         console.log(`provider=${provider.name} fullRoute:${fullRoute}`)

--- a/src/index.js
+++ b/src/index.js
@@ -186,7 +186,7 @@ function bindPluginOverrides (provider, controller, server, pluginRoutes) {
   const name = provider.namespace || provider.plugin_name || provider.name
   const namespace = name.replace(/\s/g, '').toLowerCase()
   pluginRoutes.forEach(route => {
-    let fullRoute = helpers.composeRouteString(route.path, namespace, {hosts: provider.hosts, disableIdParam: provider.disableIdParam, skipDecoration: route.skipDecoration})
+    let fullRoute = helpers.composeRouteString(route.path, namespace, {hosts: provider.hosts, disableIdParam: provider.disableIdParam, absolutePath: route.absolutePath})
     route.methods.forEach(method => {
       try {
         console.log(`provider=${provider.name} fullRoute:${fullRoute}`)

--- a/src/index.js
+++ b/src/index.js
@@ -186,7 +186,7 @@ function bindPluginOverrides (provider, controller, server, pluginRoutes) {
   const name = provider.namespace || provider.plugin_name || provider.name
   const namespace = name.replace(/\s/g, '').toLowerCase()
   pluginRoutes.forEach(route => {
-    let fullRoute = helpers.composeRouteString(namespace, route.path, {hosts: provider.hosts, disableIdParam: provider.disableIdParam, skipDecoration: route.skipDecoration})
+    let fullRoute = helpers.composeRouteString(route.path, namespace, {hosts: provider.hosts, disableIdParam: provider.disableIdParam, skipDecoration: route.skipDecoration})
     route.methods.forEach(method => {
       try {
         console.log(`provider=${provider.name} fullRoute:${fullRoute}`)

--- a/test/helpers-test.js
+++ b/test/helpers-test.js
@@ -22,22 +22,22 @@ describe('Tests for helper functions', function () {
     })
 
     it('create route with templated $namespace$ and $providerParams$ substrings', function () {
-      let fullRoute = helpers.composeRouteString('$namespace$/rest/services/$providerParams$/FeatureServer/:layer/:method','test', {hosts: true})
+      let fullRoute = helpers.composeRouteString('$namespace/rest/services/$providerParams/FeatureServer/:layer/:method','test', {hosts: true})
       fullRoute.should.equal('/test/rest/services/:host/:id/FeatureServer/:layer/:method')
     })
 
     it('create route with templated $namespace$ substring', function () {
-      let fullRoute = helpers.composeRouteString('$namespace$/rest/services/FeatureServer/:layer/:method','test', {disableIdParam: true})
+      let fullRoute = helpers.composeRouteString('$namespace/rest/services/FeatureServer/:layer/:method','test', {disableIdParam: true})
       fullRoute.should.equal('/test/rest/services/FeatureServer/:layer/:method')
     })
 
     it('create route with templated $namespace$ substring', function () {
-      let fullRoute = helpers.composeRouteString('$namespace$/rest/services/FeatureServer/:layer/:method','test')
+      let fullRoute = helpers.composeRouteString('$namespace/rest/services/FeatureServer/:layer/:method','test')
       fullRoute.should.equal('/test/:id/rest/services/FeatureServer/:layer/:method')
     })
 
     it('create route with templated $namespace$ substring', function () {
-      let fullRoute = helpers.composeRouteString('$providerParams$/rest/services/FeatureServer/:layer/:method','test')
+      let fullRoute = helpers.composeRouteString('$providerParams/rest/services/FeatureServer/:layer/:method','test')
       fullRoute.should.equal('/test/:id/rest/services/FeatureServer/:layer/:method')
     })
 

--- a/test/helpers-test.js
+++ b/test/helpers-test.js
@@ -4,26 +4,31 @@ const should = require('should') // eslint-disable-line
 describe('Tests for helper functions', function () {
   describe('Tests for composeRouteString', function () {
     it('create route with :host and :id parameter', function () {
-      let fullRoute = helpers.composeRouteString('test', 'FeatureServer/:layer/:method', true)
+      let fullRoute = helpers.composeRouteString('FeatureServer/:layer/:method', 'test',  {hosts: true})
       fullRoute.should.equal('/test/:host/:id/FeatureServer/:layer/:method')
     })
     it('create route with :host parameter', function () {
-      let fullRoute = helpers.composeRouteString('test', 'FeatureServer/:layer/:method', true, true)
+      let fullRoute = helpers.composeRouteString('FeatureServer/:layer/:method', 'test', {hosts: true})
       fullRoute.should.equal('/test/:host/:id/FeatureServer/:layer/:method')
     })
     it('create route without :host parameter', function () {
-      let fullRoute = helpers.composeRouteString('test', 'FeatureServer/:layer/:method')
+      let fullRoute = helpers.composeRouteString('FeatureServer/:layer/:method', 'test')
       fullRoute.should.equal('/test/:id/FeatureServer/:layer/:method')
     })
 
     it('create route without :host and :id parameter', function () {
-      let fullRoute = helpers.composeRouteString('test', 'FeatureServer/:layer/:method', undefined, true)
+      let fullRoute = helpers.composeRouteString('FeatureServer/:layer/:method', 'test', {disableIdParam: true})
       fullRoute.should.equal('/test/FeatureServer/:layer/:method')
     })
 
     it('create route with templated $provider$ substring', function () {
-      let fullRoute = helpers.composeRouteString('test', 'rest/services/$provider$/FeatureServer/:layer/:method', true)
+      let fullRoute = helpers.composeRouteString('rest/services/$provider$/FeatureServer/:layer/:method','test', {hosts: true})
       fullRoute.should.equal('/rest/services/test/:host/:id/FeatureServer/:layer/:method')
+    })
+
+    it('create route without decoration', function () {
+      let fullRoute = helpers.composeRouteString('rest/info','test', {skipDecoration: true})
+      fullRoute.should.equal('/rest/info')
     })
 
   })

--- a/test/helpers-test.js
+++ b/test/helpers-test.js
@@ -21,9 +21,19 @@ describe('Tests for helper functions', function () {
       fullRoute.should.equal('/test/FeatureServer/:layer/:method')
     })
 
-    it('create route with templated $provider$ substring', function () {
-      let fullRoute = helpers.composeRouteString('rest/services/$provider$/FeatureServer/:layer/:method','test', {hosts: true})
-      fullRoute.should.equal('/rest/services/test/:host/:id/FeatureServer/:layer/:method')
+    it('create route with templated $namespace$ and $providerParams$ substrings', function () {
+      let fullRoute = helpers.composeRouteString('$namespace$/rest/services/$providerParams$/FeatureServer/:layer/:method','test', {hosts: true})
+      fullRoute.should.equal('/test/rest/services/:host/:id/FeatureServer/:layer/:method')
+    })
+
+    it('create route with templated $namespace$ substring', function () {
+      let fullRoute = helpers.composeRouteString('$namespace$/rest/services/FeatureServer/:layer/:method','test', {disableIdParam: true})
+      fullRoute.should.equal('/test/rest/services/FeatureServer/:layer/:method')
+    })
+
+    it('create route with templated $namespace$ substring', function () {
+      let fullRoute = helpers.composeRouteString('$namespace$/rest/services/FeatureServer/:layer/:method','test')
+      fullRoute.should.equal('/test/:id/rest/services/FeatureServer/:layer/:method')
     })
 
     it('create route without decoration', function () {

--- a/test/helpers-test.js
+++ b/test/helpers-test.js
@@ -36,6 +36,11 @@ describe('Tests for helper functions', function () {
       fullRoute.should.equal('/test/:id/rest/services/FeatureServer/:layer/:method')
     })
 
+    it('create route with templated $namespace$ substring', function () {
+      let fullRoute = helpers.composeRouteString('$providerParams$/rest/services/FeatureServer/:layer/:method','test')
+      fullRoute.should.equal('/test/:id/rest/services/FeatureServer/:layer/:method')
+    })
+
     it('create route without decoration', function () {
       let fullRoute = helpers.composeRouteString('rest/info','test', {absolutePath: true})
       fullRoute.should.equal('/rest/info')

--- a/test/helpers-test.js
+++ b/test/helpers-test.js
@@ -1,0 +1,30 @@
+var helpers = require('../src/helpers')
+const should = require('should') // eslint-disable-line
+
+describe('Tests for helper functions', function () {
+  describe('Tests for composeRouteString', function () {
+    it('create route with :host and :id parameter', function () {
+      let fullRoute = helpers.composeRouteString('test', 'FeatureServer/:layer/:method', true)
+      fullRoute.should.equal('/test/:host/:id/FeatureServer/:layer/:method')
+    })
+    it('create route with :host parameter', function () {
+      let fullRoute = helpers.composeRouteString('test', 'FeatureServer/:layer/:method', true, true)
+      fullRoute.should.equal('/test/:host/:id/FeatureServer/:layer/:method')
+    })
+    it('create route without :host parameter', function () {
+      let fullRoute = helpers.composeRouteString('test', 'FeatureServer/:layer/:method')
+      fullRoute.should.equal('/test/:id/FeatureServer/:layer/:method')
+    })
+
+    it('create route without :host and :id parameter', function () {
+      let fullRoute = helpers.composeRouteString('test', 'FeatureServer/:layer/:method', undefined, true)
+      fullRoute.should.equal('/test/FeatureServer/:layer/:method')
+    })
+
+    it('create route with templated $provider$ substring', function () {
+      let fullRoute = helpers.composeRouteString('test', 'rest/services/$provider$/FeatureServer/:layer/:method', true)
+      fullRoute.should.equal('/rest/services/test/:host/:id/FeatureServer/:layer/:method')
+    })
+
+  })
+})

--- a/test/helpers-test.js
+++ b/test/helpers-test.js
@@ -27,7 +27,7 @@ describe('Tests for helper functions', function () {
     })
 
     it('create route without decoration', function () {
-      let fullRoute = helpers.composeRouteString('rest/info','test', {skipDecoration: true})
+      let fullRoute = helpers.composeRouteString('rest/info','test', {absolutePath: true})
       fullRoute.should.equal('/rest/info')
     })
 


### PR DESCRIPTION
Rework of route-compostion helper function.  For plugins routes, it looks for placeholders `$namespace$` and `$providerParams$` in the defined `route.path` and replaces them.  If not present, defaults to former prefixing pattern `namespace/:host/:id`.  Also handles case where only one of `$namespace$` or `$providerParams$` are found; if `$namespace$` is found, but `$providerParams$` is not, the provider params are added directly after the namespace. If `$providerParams$` is found, but `$namespace$` is not, the provider namespace is prefixed to the route (assumes that namespace should always precede provider params).