### PR TITLE
Prevent addition of :host/:id to routes with $namespace but no $providerParams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unrelease
+### Added
+* plugin routes can override a provider's settings for `hosts` and `disableIdParam` when constructing route paths.
+
 ## [3.6.0] - 2018-04-25
 ### Added
 * helper module and function to create route paths with decoration based on passed options

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## Unrelease
-### Added
-* plugin routes can override a provider's settings for `hosts` and `disableIdParam` when constructing route paths.
+## Unreleased
+### Fixed
+* Routes with a $namespace placeholder require a $providerParams placeholder to also receive the `:host/:id` URL fragment.
 
 ## [3.6.0] - 2018-04-25
 ### Added

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "express": "^4.14.1",
     "koop-cache-memory": "^1.0.2",
     "koop-localfs": "^1.1.1",
-    "koop-output-geoservices": "^1.0.0",
+    "koop-output-geoservices": "^1.2.0",
     "lodash": "^4.17.10"
   },
   "devDependencies": {

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -24,7 +24,7 @@ function composeRouteString(routePath, namespace, opts) {
   if (routePath.includes(namespacePlaceholder) && routePath.includes(paramsPlaceholder)) {
     return path.posix.join('/', routePath.replace(namespacePlaceholder, namespace).replace(paramsPlaceholder, paramFragment))
   } else if (routePath.includes(namespacePlaceholder)) {
-    return path.posix.join('/', routePath.replace(namespacePlaceholder, path.posix.join(namespace, paramFragment)))
+    return path.posix.join('/', routePath.replace(namespacePlaceholder, namespace))
   } else if (routePath.includes(paramsPlaceholder)) {
     return path.posix.join('/', namespace, routePath.replace(paramsPlaceholder, paramFragment))
   } else {

--- a/src/index.js
+++ b/src/index.js
@@ -186,7 +186,13 @@ function bindPluginOverrides (provider, controller, server, pluginRoutes) {
   const name = provider.namespace || provider.plugin_name || provider.name
   const namespace = name.replace(/\s/g, '').toLowerCase()
   pluginRoutes.forEach(route => {
-    let fullRoute = helpers.composeRouteString(route.path, namespace, {hosts: provider.hosts, disableIdParam: provider.disableIdParam, absolutePath: route.absolutePath})
+    let fullRoute = helpers.composeRouteString(route.path, namespace, {
+      // Override provider's hosts parameter if defined on route
+      hosts: ((route.hosts !== undefined) ? route.hosts : provider.hosts), 
+      // Override provider's disableIdParam if defined on route
+      disableIdParam: ((route.disableIdParam !== undefined) ? route.disableIdParam : provider.disableIdParam), 
+      absolutePath: route.absolutePath
+    })
     route.methods.forEach(method => {
       try {
         console.log(`provider=${provider.name} fullRoute:${fullRoute}`)

--- a/src/index.js
+++ b/src/index.js
@@ -187,10 +187,8 @@ function bindPluginOverrides (provider, controller, server, pluginRoutes) {
   const namespace = name.replace(/\s/g, '').toLowerCase()
   pluginRoutes.forEach(route => {
     let fullRoute = helpers.composeRouteString(route.path, namespace, {
-      // Override provider's hosts parameter if defined on route
-      hosts: ((route.hosts !== undefined) ? route.hosts : provider.hosts), 
-      // Override provider's disableIdParam if defined on route
-      disableIdParam: ((route.disableIdParam !== undefined) ? route.disableIdParam : provider.disableIdParam), 
+      hosts: provider.hosts, 
+      disableIdParam: provider.disableIdParam, 
       absolutePath: route.absolutePath
     })
     route.methods.forEach(method => {

--- a/test/helpers-test.js
+++ b/test/helpers-test.js
@@ -33,7 +33,7 @@ describe('Tests for helper functions', function () {
 
     it('create route with templated $namespace$ substring', function () {
       let fullRoute = helpers.composeRouteString('$namespace/rest/services/FeatureServer/:layer/:method','test')
-      fullRoute.should.equal('/test/:id/rest/services/FeatureServer/:layer/:method')
+      fullRoute.should.equal('/test/rest/services/FeatureServer/:layer/:method')
     })
 
     it('create route with templated $namespace$ substring', function () {

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -11,7 +11,7 @@ describe('Index tests for registering providers', function () {
       koop.register(provider)
       const routeCount = (koop.server._router.stack.length)
       // TODO make this test less brittle
-      routeCount.should.equal(38)
+      routeCount.should.equal(58)
     })
   })
 })


### PR DESCRIPTION
If a route contains the `$namespace` placeholder, but no `$providerParams` placeholder, `:host/:id` are omitted by default, regardless of the provider's `hosts` and `disableIdParam` property-values.  This is important for special-case routes like `$namespace/rest/info` which currently are being constructed like `namespace/:host/:id/rest/info`.