### PR TITLE
Rework `authenticationSpecification` on Model prototype

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,12 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+### Fixed
+* Auth plugin registration now adds `authenticationSpecification` to Model prototype
+
 ## [3.7.1] - 2018-06-01
+### Fixed
 * Explicitly bump koop-output-geoservices to 1.5.1
 
 ## [3.7.0] - 2018-05-22

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
   },
   "scripts": {
     "release": "gh-release",
+    "clean": "rm -rf dist",
     "compile": "buble -i src -o dist",
     "test": "NODE_ENV=test standard src && mocha test/*.js -t 5000"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -123,7 +123,7 @@ Koop.prototype._registerProvider = function (provider) {
   
   // If an authentication module has been registered, apply it to the provider's Model
   if(this._auth_module) {
-    provider.Model.prototype.authenticationSpecification = this._auth_module.getAuthenticationSpecification(provider.name)
+    provider.Model.prototype.authenticationSpecification = Object.assign({}, this._auth_module.authenticationSpecification(provider.name), {provider: provider.name})
     provider.Model.prototype.authenticate = this._auth_module.authenticate
     provider.Model.prototype.authorize = this._auth_module.authorize
   }


### PR DESCRIPTION
Rework `authenticationSpecification` on Model prototype.  Mixes-in provider name to auth-spec object.