### PR TITLE
Parse/coerce request query params

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -78,6 +78,8 @@ function initServer () {
     next()
   }) 
   .use(middleware.paramTrim)
+  .use(middleware.paramParse)
+  .use(middleware.paramCoerce)
   // for demos and preview maps in providers
   .set('view engine', 'ejs')
   .use(express.static(path.join(__dirname, '/public')))

--- a/src/middleware/index.js
+++ b/src/middleware/index.js
@@ -1,8 +1,8 @@
 /**
  * Middleware to trim whitespace from incoming string parameters
- * @param {*} req 
- * @param {*} res 
- * @param {*} next 
+ * @param {object} req request object
+ * @param {object} res response object
+ * @param {function} next fire next middleware function
  */
 function paramTrim(req, res, next) {
   Object.keys(req.query).map(param=>{
@@ -13,10 +13,10 @@ function paramTrim(req, res, next) {
 }
 
 /**
- * 
- * @param {*} req 
- * @param {*} res 
- * @param {*} next 
+ * Parse any request query parameters that arrive as JSON strings
+ * @param {object} req request object
+ * @param {object} res response object
+ * @param {function} next fire next middleware function
  */
 function paramParse(req, res, next) {
   Object.keys(req.query).map(param=>{
@@ -25,6 +25,25 @@ function paramParse(req, res, next) {
   next()
 }
 
+/**
+ * Coerce any string booleans to booleans
+ * @param {object} req request object
+ * @param {object} res response object
+ * @param {function} next fire next middleware function
+ */
+function paramCoerce (req, res, next) {
+  Object.keys(req.query).forEach(param => {
+    if (req.query[param] === 'false') req.query[param] = false
+    else if (req.query[param] === 'true') req.query[param] = true
+  })
+  next()
+}
+
+/**
+ * Attempt to parse as JSON and return. If parsing fails, return input
+ * @param {*} json
+ * @returns {*}
+ */
 function tryParse (json) {
   try {
     return JSON.parse(json)
@@ -33,14 +52,6 @@ function tryParse (json) {
   }
 }
 
-function coerceQuery (params) {
-  Object.keys(params).forEach(param => {
-    if (params[param] === 'false') params[param] = false
-    else if (params[param] === 'true') params[param] = true
-  })
-  return params
-}
-
 module.exports = {
-  paramTrim, paramParse
+  paramTrim, paramParse, paramCoerce
 }

--- a/src/middleware/index.js
+++ b/src/middleware/index.js
@@ -12,6 +12,35 @@ function paramTrim(req, res, next) {
   next()
 }
 
+/**
+ * 
+ * @param {*} req 
+ * @param {*} res 
+ * @param {*} next 
+ */
+function paramParse(req, res, next) {
+  Object.keys(req.query).map(param=>{
+    req.query[param] = tryParse(req.query[param])
+    })
+  next()
+}
+
+function tryParse (json) {
+  try {
+    return JSON.parse(json)
+  } catch (e) {
+    return json
+  }
+}
+
+function coerceQuery (params) {
+  Object.keys(params).forEach(param => {
+    if (params[param] === 'false') params[param] = false
+    else if (params[param] === 'true') params[param] = true
+  })
+  return params
+}
+
 module.exports = {
-  paramTrim
+  paramTrim, paramParse
 }

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -12,7 +12,7 @@ describe('Index tests for registering providers', function () {
       koop.register(provider)
       const routeCount = (koop.server._router.stack.length)
       // TODO make this test less brittle
-      routeCount.should.equal(82)
+      routeCount.should.equal(84)
     })
   })
 })

--- a/test/middleware-test.js
+++ b/test/middleware-test.js
@@ -2,7 +2,7 @@ const middleware = require('../src/middleware');
 const should = require('should') // eslint-disable-line
 
 describe('Middleware tests', function () {
-  describe('paramsTrim function', function () {
+  describe('paramTrim function', function () {
     
     it('should trim leading and trail white space from body params', function () {
       const req = {query: { param1: ' needs-a-trim '} };
@@ -14,6 +14,22 @@ describe('Middleware tests', function () {
       const req = {query: { param1: 1} };
       middleware.paramTrim(req, {}, function(){});
       req.query.param1.should.equal(1)
+    })
+  })
+
+  describe('paramParse function', function () {
+    it('should convert a JSON (escaped) string parameter to a JSON object', function () {
+      const req = {query: { param1: '{\"jsonstr\":\"foobar\"}'} };
+      middleware.paramParse(req, {}, function(){});
+      req.query.param1.hasOwnProperty('jsonstr').should.equal(true)
+      req.query.param1.jsonstr.should.equal('foobar')
+    })
+
+    it('should convert a JSON string parameter to a JSON object', function () {
+      const req = {query: { param1: '{"jsonstr":"foobar"}'} };
+      middleware.paramParse(req, {}, function(){});
+      req.query.param1.hasOwnProperty('jsonstr').should.equal(true)
+      req.query.param1.jsonstr.should.equal('foobar')
     })
   })
 })

--- a/test/middleware-test.js
+++ b/test/middleware-test.js
@@ -32,6 +32,15 @@ describe('Middleware tests', function () {
       req.query.param1.jsonstr.should.equal('foobar')
     })
   })
+
+  describe('paramCoerce function', function () {
+    it('should convert strings "true" or "false" to booleans', function () {
+      const req = {query: { param1: 'true', param2: 'false'} };
+      middleware.paramCoerce(req, {}, function(){});
+      req.query.param1.should.equal(true)
+      req.query.param2.should.equal(false)
+    })
+  })
 })
 
 


### PR DESCRIPTION
- JSON parameters sent in GET requests arrive as strings.  Thus they should get parsed.
- Boolean parameters arriving as GET strings should be coerced to boolean types.