### PR TITLE
Fix route construction where disbleIdParam = true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+# Unreleased
+### Fixed
+* Routes where `hosts: true` and `disableIdParam: true` now being constructed correctly as `/:host/FeatureServer/:layer/:method`
+
 ## [3.9.0] - 2018-07-20
 ### Added
 * Prefentially use a `createKey` function found on the Model's prototype

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -16,7 +16,8 @@ function composeRouteString (routePath, namespace, opts) {
   if (options.absolutePath) return path.posix.join('/', routePath)
 
   // Build parameterized route fragment based on provider options
-  if (options.hosts) paramFragment = path.posix.join(':host', ':id')
+  if (options.hosts && !options.disableIdParam) paramFragment = path.posix.join(':host', ':id')
+  else if (options.hosts && options.disableIdParam) paramFragment = path.posix.join(':host')
   else if (!options.disableIdParam) paramFragment = path.posix.join(':id')
 
   // Replace placehold substrings if present, fallback to namespace/:host/:id

--- a/test/helpers-test.js
+++ b/test/helpers-test.js
@@ -7,10 +7,11 @@ describe('Tests for helper functions', function () {
       let fullRoute = helpers.composeRouteString('FeatureServer/:layer/:method', 'test', {hosts: true})
       fullRoute.should.equal('/test/:host/:id/FeatureServer/:layer/:method')
     })
-    it('create route with :host parameter', function () {
-      let fullRoute = helpers.composeRouteString('FeatureServer/:layer/:method', 'test', {hosts: true})
-      fullRoute.should.equal('/test/:host/:id/FeatureServer/:layer/:method')
+    it('create route with :host parameter and without :id parameter', function () {
+      let fullRoute = helpers.composeRouteString('FeatureServer/:layer/:method', 'test', {hosts: true, disableIdParam: true})
+      fullRoute.should.equal('/test/:host/FeatureServer/:layer/:method')
     })
+
     it('create route without :host parameter', function () {
       let fullRoute = helpers.composeRouteString('FeatureServer/:layer/:method', 'test')
       fullRoute.should.equal('/test/:id/FeatureServer/:layer/:method')


### PR DESCRIPTION
When provider had `disableIdParam: true` routes were still being built as `/:host/:id/FeatureServer/:layer/:method`.  This PR corrects that.