### PR TITLE
Make name-check throw error on undefined.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+### Fixed
+* Throw error on plugin name undefined, not defined
+
 ## [3.9.3] - 2018-09-05
 ### Changed
 ** Bump koop-output-geoservices version to 2.0.0

--- a/src/index.js
+++ b/src/index.js
@@ -265,7 +265,7 @@ Koop.prototype._registerFilesystem = function (Filesystem) {
  */
 Koop.prototype._registerPlugin = function (Plugin) {
   const name = Plugin.name || Plugin.plugin_name
-  if (name) throw new Error('Plugin is missing name')
+  if (!name) throw new Error('Plugin is missing name')
   let dependencies
   if (typeof Plugin.dependencies && Plugin.dependencies.length) {
     dependencies = Plugin.dependencies.reduce((deps, dep) => {


### PR DESCRIPTION
Looks like we have a bug in generic plugin registration.  See issue https://github.com/koopjs/koop-core/issues/50;  This PR makes the adjustment to remedy.