### PR TITLE
Auth options

### DIFF
--- a/test/dataset-test.js
+++ b/test/dataset-test.js
@@ -75,7 +75,7 @@ describe('Datsets API', function () {
     })
 
     it('should delete metadata on DELETE', done => {
-      koop.cache.insert('deleteMetaKey', { foo: 'bar' })
+      koop.cache.catalog.insert('deleteMetaKey', { foo: 'bar' })
       request(koop.server)
         .delete('/datasets/deleteMetaKey/metadata')
         .expect(200)

--- a/test/fixtures/fake-auth/index.js
+++ b/test/fixtures/fake-auth/index.js
@@ -2,7 +2,7 @@
 function fakeAuth () {
   return {
     type: 'auth',
-    getAuthenticationSpecification: function () {
+    authenticationSpecification: function () {
       return function () { }
     },
     authenticate: function () {},

--- a/test/fixtures/fake-provider-ii/index.js
+++ b/test/fixtures/fake-provider-ii/index.js
@@ -1,0 +1,4 @@
+exports.name = 'test-provider-ii'
+exports.type = 'provider'
+exports.status = { version: '0.0.0' }
+exports.Model = require('./models/fake')

--- a/test/fixtures/fake-provider-ii/models/fake.js
+++ b/test/fixtures/fake-provider-ii/models/fake.js
@@ -1,0 +1,7 @@
+function Fake () {
+  this.find = function find (id, options, callback) {
+    callback(null, [{}])
+  }
+}
+
+module.exports = Fake

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -30,7 +30,6 @@ describe('Tests for registering auth plugin', function () {
 
   describe('can register an auth plugin and apply methods to a provider', function () {
     it('should register successfully', function () {
-
       const koop = new Koop()
       koop.register(auth)
       koop.register(provider)
@@ -57,6 +56,4 @@ describe('Tests for registering auth plugin', function () {
       providerWithAuth.Model.prototype.should.have.property('authorize')
     })
   })
-
 })
-

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -1,30 +1,44 @@
 /* global describe, it */
+// const auth = require('./fixtures/fake-auth')()
+// const Koop = require('../src/')
+// const provider = require('./fixtures/fake-provider')
 
-var provider = require('./fixtures/fake-provider')
-var auth = require('./fixtures/fake-auth')()
-const Koop = require('../src/')
-const koop = new Koop()
-const should = require('should') // eslint-disable-line
+// const should = require('should') // eslint-disable-line
 
-describe('Index tests for registering providers', function () {
-  describe('can register a provider', function () {
-    it('should register successfully', function () {
-      koop.register(provider)
-      const routeCount = (koop.server._router.stack.length)
-      // TODO make this test less brittle
-      routeCount.should.equal(84)
-    })
-  })
-})
+// describe('Index tests for registering providers', function () {
+//   describe('can register a provider', function () {
+//     it('should register successfully', function () {
+//       const koop = new Koop()
+//       koop.register(provider)
+//       const routeCount = (koop.server._router.stack.length)
+//       // TODO make this test less brittle
+//       routeCount.should.equal(84)
+//     })
+//   })
+// })
 
-describe('Tests for registering auth plugin', function () {
-  describe('can register an auth plugin', function () {
-    it('should register successfully', function () {
-      koop.register(auth)
-      koop._auth_module.should.be.instanceOf(Object)
-      koop._auth_module.authenticate.should.be.instanceOf(Function)
-      koop._auth_module.authorize.should.be.instanceOf(Function)
-      koop._auth_module.authenticationSpecification.should.be.instanceOf(Function)
-    })
-  })
-})
+// describe('Tests for registering auth plugin', function () {
+//   describe('can register an auth plugin', function () {
+//     it('should register successfully', function () {
+//       const koop = new Koop()
+//       koop.register(auth)
+//       koop._auth_module.should.be.instanceOf(Object)
+//       koop._auth_module.authenticate.should.be.instanceOf(Function)
+//       koop._auth_module.authorize.should.be.instanceOf(Function)
+//       koop._auth_module.authenticationSpecification.should.be.instanceOf(Function)
+//     })
+//   })
+// })
+
+// describe('Tests for registering and provider with auth plugin', function () {
+//   describe('can register an auth plugin', function () {
+//     it('should register successfully', function () {
+//       const provider = require('./fixtures/fake-provider')
+//       const auth = require('./fixtures/fake-auth')()
+//       const koop = new Koop()
+//       koop.register(auth)
+//       koop.register(provider)
+//       provider.Model.prototype.should.have.property('authenticationSpecification')
+//     })
+//   })
+// })

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -1,44 +1,43 @@
 /* global describe, it */
-// const auth = require('./fixtures/fake-auth')()
-// const Koop = require('../src/')
-// const provider = require('./fixtures/fake-provider')
+const auth = require('./fixtures/fake-auth')()
+const Koop = require('../src/')
+const should = require('should') // eslint-disable-line
 
-// const should = require('should') // eslint-disable-line
+describe('Index tests for registering providers', function () {
+  describe('can register a provider', function () {
+    it('should register successfully', function () {
+      const provider = require('./fixtures/fake-provider')
+      const koop = new Koop()
+      koop.register(provider)
+      const routeCount = (koop.server._router.stack.length)
+      // TODO make this test less brittle
+      routeCount.should.equal(84)
+    })
+  })
+})
 
-// describe('Index tests for registering providers', function () {
-//   describe('can register a provider', function () {
-//     it('should register successfully', function () {
-//       const koop = new Koop()
-//       koop.register(provider)
-//       const routeCount = (koop.server._router.stack.length)
-//       // TODO make this test less brittle
-//       routeCount.should.equal(84)
-//     })
-//   })
-// })
+describe('Tests for registering auth plugin', function () {
+  describe('can register an auth plugin', function () {
+    it('should register successfully', function () {
+      const koop = new Koop()
+      koop.register(auth)
+      koop._auth_module.should.be.instanceOf(Object)
+      koop._auth_module.authenticate.should.be.instanceOf(Function)
+      koop._auth_module.authorize.should.be.instanceOf(Function)
+      koop._auth_module.authenticationSpecification.should.be.instanceOf(Function)
+    })
+  })
+})
 
-// describe('Tests for registering auth plugin', function () {
-//   describe('can register an auth plugin', function () {
-//     it('should register successfully', function () {
-//       const koop = new Koop()
-//       koop.register(auth)
-//       koop._auth_module.should.be.instanceOf(Object)
-//       koop._auth_module.authenticate.should.be.instanceOf(Function)
-//       koop._auth_module.authorize.should.be.instanceOf(Function)
-//       koop._auth_module.authenticationSpecification.should.be.instanceOf(Function)
-//     })
-//   })
-// })
-
-// describe('Tests for registering and provider with auth plugin', function () {
-//   describe('can register an auth plugin', function () {
-//     it('should register successfully', function () {
-//       const provider = require('./fixtures/fake-provider')
-//       const auth = require('./fixtures/fake-auth')()
-//       const koop = new Koop()
-//       koop.register(auth)
-//       koop.register(provider)
-//       provider.Model.prototype.should.have.property('authenticationSpecification')
-//     })
-//   })
-// })
+describe('Tests for registering and provider with auth plugin', function () {
+  describe('can register an auth plugin', function () {
+    it('should register successfully', function () {
+      const provider = require('./fixtures/fake-provider')
+      const auth = require('./fixtures/fake-auth')()
+      const koop = new Koop()
+      koop.register(auth)
+      koop.register(provider)
+      provider.Model.prototype.should.have.property('authenticationSpecification')
+    })
+  })
+})

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -24,7 +24,7 @@ describe('Tests for registering auth plugin', function () {
       koop._auth_module.should.be.instanceOf(Object)
       koop._auth_module.authenticate.should.be.instanceOf(Function)
       koop._auth_module.authorize.should.be.instanceOf(Function)
-      koop._auth_module.getAuthenticationSpecification.should.be.instanceOf(Function)
+      koop._auth_module.authenticationSpecification.should.be.instanceOf(Function)
     })
   })
 })

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -1,4 +1,5 @@
 /* global describe, it */
+const provider = require('./fixtures/fake-provider')
 const auth = require('./fixtures/fake-auth')()
 const Koop = require('../src/')
 const should = require('should') // eslint-disable-line
@@ -6,7 +7,6 @@ const should = require('should') // eslint-disable-line
 describe('Index tests for registering providers', function () {
   describe('can register a provider', function () {
     it('should register successfully', function () {
-      const provider = require('./fixtures/fake-provider')
       const koop = new Koop()
       koop.register(provider)
       const routeCount = (koop.server._router.stack.length)
@@ -27,17 +27,36 @@ describe('Tests for registering auth plugin', function () {
       koop._auth_module.authenticationSpecification.should.be.instanceOf(Function)
     })
   })
-})
 
-describe('Tests for registering and provider with auth plugin', function () {
-  describe('can register an auth plugin', function () {
+  describe('can register an auth plugin and apply methods to a provider', function () {
     it('should register successfully', function () {
-      const provider = require('./fixtures/fake-provider')
-      const auth = require('./fixtures/fake-auth')()
+
       const koop = new Koop()
       koop.register(auth)
       koop.register(provider)
       provider.Model.prototype.should.have.property('authenticationSpecification')
+      provider.Model.prototype.should.have.property('authenticate')
+      provider.Model.prototype.should.have.property('authorize')
     })
   })
+
+  describe('can register an auth plugin and selectively apply methods to a provider', function () {
+    it('should register successfully', function () {
+      const providerWithAuth = require('./fixtures/fake-provider')
+      const providerWithoutAuth = require('./fixtures/fake-provider-ii')
+      const auth = require('./fixtures/fake-auth')()
+      const koop = new Koop()
+      koop.register(providerWithoutAuth)
+      koop.register(auth)
+      koop.register(providerWithAuth)
+      providerWithoutAuth.Model.prototype.should.not.have.property('authenticationSpecification')
+      providerWithoutAuth.Model.prototype.should.not.have.property('authenticate')
+      providerWithoutAuth.Model.prototype.should.not.have.property('authorize')
+      providerWithAuth.Model.prototype.should.have.property('authenticationSpecification')
+      providerWithAuth.Model.prototype.should.have.property('authenticate')
+      providerWithAuth.Model.prototype.should.have.property('authorize')
+    })
+  })
+
 })
+


### PR DESCRIPTION
Add tests and fixtures to test that the auth-plugin can be applied to providers selectively - by registering providers _after_ the auth-plugin.