### PR TITLE
Add route-prefix option to provider registration.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+## Added
+* Option to add route prefix per provider
+
 ## [3.9.4] - 2018-09-13
 ### Fixed
 * Throw error on plugin name undefined, not defined

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -6,29 +6,29 @@ const path = require('path')
  * @param {string} namespace - namespace for the route
  * @param {object} options - options object with decoration flags
  */
-function composeRouteString (routePath, namespace, opts) {
-  let options = opts || {}
+function composeRouteString (routePath, namespace, options = {}) {
+  const { hosts, disableIdParam, absolutePath, routePrefix = '' } = options
   let paramFragment = ''
   const paramsPlaceholder = '$providerParams'
   const namespacePlaceholder = '$namespace'
 
   // No compostion needed if flagged as an absolute route
-  if (options.absolutePath) return path.posix.join('/', routePath)
+  if (absolutePath) return path.posix.join(routePrefix, '/', routePath)
 
   // Build parameterized route fragment based on provider options
-  if (options.hosts && !options.disableIdParam) paramFragment = path.posix.join(':host', ':id')
-  else if (options.hosts && options.disableIdParam) paramFragment = path.posix.join(':host')
-  else if (!options.disableIdParam) paramFragment = path.posix.join(':id')
+  if (hosts && !disableIdParam) paramFragment = path.posix.join(':host', ':id')
+  else if (hosts && disableIdParam) paramFragment = path.posix.join(':host')
+  else if (!disableIdParam) paramFragment = path.posix.join(':id')
 
   // Replace placehold substrings if present, fallback to namespace/:host/:id
   if (routePath.includes(namespacePlaceholder) && routePath.includes(paramsPlaceholder)) {
-    return path.posix.join('/', routePath.replace(namespacePlaceholder, namespace).replace(paramsPlaceholder, paramFragment))
+    return path.posix.join(routePrefix, '/', routePath.replace(namespacePlaceholder, namespace).replace(paramsPlaceholder, paramFragment))
   } else if (routePath.includes(namespacePlaceholder)) {
-    return path.posix.join('/', routePath.replace(namespacePlaceholder, namespace))
+    return path.posix.join(routePrefix, '/', routePath.replace(namespacePlaceholder, namespace))
   } else if (routePath.includes(paramsPlaceholder)) {
-    return path.posix.join('/', namespace, routePath.replace(paramsPlaceholder, paramFragment))
+    return path.posix.join(routePrefix, '/', namespace, routePath.replace(paramsPlaceholder, paramFragment))
   } else {
-    return path.posix.join('/', namespace, paramFragment, routePath)
+    return path.posix.join(routePrefix, '/', namespace, paramFragment, routePath)
   }
 }
 module.exports = { composeRouteString }

--- a/test/helpers-test.js
+++ b/test/helpers-test.js
@@ -46,5 +46,20 @@ describe('Tests for helper functions', function () {
       let fullRoute = helpers.composeRouteString('rest/info', 'test', { absolutePath: true })
       fullRoute.should.equal('/rest/info')
     })
+
+    it('create route without prefix and :host parameter', function () {
+      let fullRoute = helpers.composeRouteString('FeatureServer/:layer/:method', 'test', { routePrefix: '/api/test' })
+      fullRoute.should.equal('/api/test/test/:id/FeatureServer/:layer/:method')
+    })
+
+    it('create route with prefix and without decoration', function () {
+      let fullRoute = helpers.composeRouteString('rest/info', 'test', { absolutePath: true, routePrefix: '/api/test' })
+      fullRoute.should.equal('/api/test/rest/info')
+    })
+
+    it('create route with prefix and templated $namespace$ and $providerParams$ substrings', function () {
+      let fullRoute = helpers.composeRouteString('$namespace/rest/services/$providerParams/FeatureServer/:layer/:method', 'test', { hosts: true })
+      fullRoute.should.equal('/test/rest/services/:host/:id/FeatureServer/:layer/:method')
+    })
   })
 })

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -2,6 +2,7 @@
 const provider = require('./fixtures/fake-provider')
 const auth = require('./fixtures/fake-auth')()
 const Koop = require('../src/')
+const request = require('supertest')
 const should = require('should') // eslint-disable-line
 
 describe('Index tests for registering providers', function () {
@@ -13,6 +14,37 @@ describe('Index tests for registering providers', function () {
       // TODO make this test less brittle
       routeCount.should.equal(84)
     })
+  })
+
+  describe('can register a provider and apply a route prefix to all routes', function () {
+    it('should not return 404 for prefixed custom route', function (done) {
+      const koop = new Koop()
+      koop.register(provider, { routePrefix: '/api/test' })
+      request(koop.server)
+        .get('/api/test/fake/1234')
+        .then((res) => {
+          res.should.have.property('error', false)
+        })
+        .catch(err => {
+          console.log(err)
+        })
+        .then(done);
+    })
+
+    it('should not return 404 for prefixed plugin route', function (done) {
+      const koop = new Koop()
+      koop.register(provider, { routePrefix: '/api/test' })
+      request(koop.server)
+        .get('/api/test/test-provider/foo/FeatureServer')
+        .then((res) => {
+          res.should.have.property('error', false)
+        })
+        .catch(err => {
+          console.log(err)
+        })
+        .then(done);;
+    })
+
   })
 })
 

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -28,7 +28,7 @@ describe('Index tests for registering providers', function () {
         .catch(err => {
           console.log(err)
         })
-        .then(done);
+        .then(done)
     })
 
     it('should not return 404 for prefixed plugin route', function (done) {
@@ -42,9 +42,8 @@ describe('Index tests for registering providers', function () {
         .catch(err => {
           console.log(err)
         })
-        .then(done);;
+        .then(done)
     })
-
   })
 })
 


### PR DESCRIPTION
This PR adds an `options` parameter to provider registration.  If the options object contains a property named `routePrefix`, it's string value will be prepended to all provider route paths.

Documentation of this new option is required in koop docs.