### PR TITLE
support options when registering a cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+### Added
+* pass in options object when registering a cache provider
+
 ## [3.10.1] - 2018-11-01
 ### Fixed
 * Use path.posix.join instead of path.join

--- a/src/index.js
+++ b/src/index.js
@@ -92,7 +92,7 @@ Koop.prototype.register = function (plugin, options) {
     case 'provider':
       return this._registerProvider(plugin, options)
     case 'cache':
-      return this._registerCache(plugin)
+      return this._registerCache(plugin, options)
     case 'plugin':
       return this._registerPlugin(plugin)
     case 'filesystem':
@@ -243,8 +243,8 @@ function bindRouteSet (routes = [], controller, server, options = {}) {
  *
  * @param {object} cache - a koop database adapter
  */
-Koop.prototype._registerCache = function (Cache) {
-  this.cache = new Cache()
+Koop.prototype._registerCache = function (Cache, options) {
+  this.cache = (typeof options !== 'undefined') ? new Cache(options) : new Cache()
   this.log.info('registered cache:', Cache.name, Cache.version)
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -94,16 +94,16 @@ Koop.prototype.register = function (plugin, options) {
     case 'cache':
       return this._registerCache(plugin, options)
     case 'plugin':
-      return this._registerPlugin(plugin)
+      return this._registerPlugin(plugin, options)
     case 'filesystem':
-      return this._registerFilesystem(plugin)
+      return this._registerFilesystem(plugin, options)
     case 'output':
-      return this._registerOutput(plugin)
+      return this._registerOutput(plugin, options)
     case 'auth':
-      return this._registerAuth(plugin)
+      return this._registerAuth(plugin, options)
     default:
       this.log.warn('Unrecognized plugin type: "' + plugin.type + '". Defaulting to provider.')
-      return this._registerProvider(plugin)
+      return this._registerProvider(plugin, options)
   }
 }
 
@@ -244,7 +244,7 @@ function bindRouteSet (routes = [], controller, server, options = {}) {
  * @param {object} cache - a koop database adapter
  */
 Koop.prototype._registerCache = function (Cache, options) {
-  this.cache = (typeof options !== 'undefined') ? new Cache(options) : new Cache()
+  this.cache = new Cache(options)
   this.log.info('registered cache:', Cache.name, Cache.version)
 }
 


### PR DESCRIPTION
support for passing in an object of configuration or connection options when registering a new Cache provider.

Example using Koop-Redis:
```
const redisOptions = {
  host: {
    host: 'koop-sdmx.redis.cache.windows.net',
    port: 6380,
    auth_pass: 'SuperSecretAuth',
    tls: { servername: 'koop-sdmx.redis.cache.windows.net' }
  }
};

koop.register(redisCache, redisOptions);
```