### PR TITLE
Pretty printing of provider/plugin routes to terminal.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+### Changed
+* console logging of provider/output routes
+
 ## [3.11.0] - 2019-03-29
 ### Added
 * pass in options object when registering a cache provider

--- a/package.json
+++ b/package.json
@@ -15,8 +15,10 @@
   "dependencies": {
     "@koopjs/logger": "^2.0.2",
     "body-parser": "^1.16.0",
+    "chalk": "^2.4.2",
     "config": "^3.0.0",
     "cors": "^2.8.1",
+    "easy-table": "^1.1.1",
     "ejs": "^2.3.3",
     "express": "^4.14.1",
     "koop-cache-memory": "^1.0.2",

--- a/src/index.js
+++ b/src/index.js
@@ -37,7 +37,7 @@ function Koop (config) {
 
   const dataset = new Dataset(this)
   const datasetController = new DatasetController(dataset)
-  bindRouteSet({ name: 'koop-cache', routes}, datasetController, this.server)
+  bindRouteSet({ name: 'koop-cache', routes }, datasetController, this.server)
 
   const fsRoutes = routes.concat(geoservices.routes.map(route => {
     return {
@@ -47,7 +47,7 @@ function Koop (config) {
     }
   }))
 
-  bindRouteSet({ name: 'koop-cache-geoservices', routes: fsRoutes}, datasetController, this.server)
+  bindRouteSet({ name: 'koop-cache-geoservices', routes: fsRoutes }, datasetController, this.server)
 
   this.status = {
     version: this.version,


### PR DESCRIPTION
Pretty printed route/methods for each provider and provider-plugin combination.  When `NODE_ENV !== 'test'` the terminal will output something like:

![Screen Shot 2019-04-11 at 7 22 29 AM](https://user-images.githubusercontent.com/4369192/55965029-9fbf3180-5c2a-11e9-839d-d172522ad1ba.png)
 