### PR TITLE
Fix feature-server route paths for cached datasets

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -237,7 +237,6 @@ function bindRouteSet (routes = [], controller, server, options = {}) {
     route.methods.forEach(method => {
       try {
         server[method](routePath, controller[route.handler].bind(controller))
-        console.log(routePath)
       } catch (e) {
         console.error(`error=controller does not contain specified method method=${method.toUpperCase()} path=${routePath} handler=${route.handler}`)
         process.exit(1)

--- a/src/index.js
+++ b/src/index.js
@@ -46,11 +46,8 @@ function Koop (config) {
     // or rest/info routes applied to cache datasets, which are not applicable
     return route.path.includes('FeatureServer') && !route.path.includes('rest/services')
   }).map(route => {
-    // Extract the fragment of the path from "FeatureServer" onward.  This is critical because the Geoservices plugin
-    // as of 2.
-    const path = route.path.substring(route.path.indexOf('FeatureServer'))
     return {
-      path: `/datasets/:id/${path}`,
+      path: `/datasets/:id/${route.path}`,
       handler: route.handler,
       methods: route.methods
     }

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -11,8 +11,7 @@ describe('Index tests for registering providers', function () {
       const koop = new Koop()
       koop.register(provider)
       const routeCount = (koop.server._router.stack.length)
-      // TODO make this test less brittle
-      routeCount.should.equal(84)
+      routeCount.should.equal(58)
     })
   })
 

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -11,7 +11,7 @@ describe('Index tests for registering providers', function () {
       const koop = new Koop()
       koop.register(provider)
       const routeCount = (koop.server._router.stack.length)
-      routeCount.should.equal(58)
+      routeCount.should.equal(78)
     })
   })
 


### PR DESCRIPTION
This PR fixes an existing bug caused by the changes to koop-output-geoservices [v1.2.0](https://github.com/koopjs/koop-output-geoservices/releases/tag/v1.2.0).  That release added a second set of routes with the `/rest/services` fragment and and placeholder for provider's `host` and `id` parameters, which need special handling to be properly bound to controllers.  Here, I change the functions that bind routes to the datasets controller so that it is compatible with current generation koop-output-geoservices.