### PR TITLE
Pretty printing of provider/plugin routes to terminal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+### Changed
+* console logging of provider/output routes
+
 ## [3.11.0] - 2019-03-29
 ### Added
 * pass in options object when registering a cache provider

--- a/package.json
+++ b/package.json
@@ -15,8 +15,10 @@
   "dependencies": {
     "@koopjs/logger": "^2.0.2",
     "body-parser": "^1.16.0",
+    "chalk": "^2.4.2",
     "config": "^3.0.0",
     "cors": "^2.8.1",
+    "easy-table": "^1.1.1",
     "ejs": "^2.3.3",
     "express": "^4.14.1",
     "koop-cache-memory": "^1.0.2",

--- a/src/index.js
+++ b/src/index.js
@@ -246,7 +246,7 @@ function bindPluginOverrides (provider, controller, server, pluginRoutes, option
     // For each output plugin, keep track of routes, methods
     pluginRouteMap[route.output] = pluginRouteMap[route.output] || {}
     pluginRouteMap[route.output][fullRoute] = pluginRouteMap[route.output][fullRoute] || []
-    
+
     // Bind the controller to each route
     route.methods.forEach(method => {
       try {
@@ -285,8 +285,6 @@ function bindRouteSet (provider, controller, server, options = {}) {
         process.exit(1)
       }
     })
-
-    
   })
 
   // Print provider routes to terminal

--- a/src/index.js
+++ b/src/index.js
@@ -37,7 +37,21 @@ function Koop (config) {
 
   const dataset = new Dataset(this)
   const datasetController = new DatasetController(dataset)
+<<<<<<< HEAD
   bindRoutes({ name: 'datasets', routes }, datasetController, this.server, this.pluginRoutes)
+=======
+  bindRouteSet({ name: 'koop-cache', routes }, datasetController, this.server)
+
+  const fsRoutes = routes.concat(geoservices.routes.map(route => {
+    return {
+      path: `/datasets/:id/${route.path}`,
+      handler: route.handler,
+      methods: route.methods
+    }
+  }))
+
+  bindRouteSet({ name: 'koop-cache-geoservices', routes: fsRoutes }, datasetController, this.server)
+>>>>>>> Remove lint.
 
   this.status = {
     version: this.version,

--- a/src/index.js
+++ b/src/index.js
@@ -19,6 +19,8 @@ const Util = require('util')
 const path = require('path')
 const geoservices = require('koop-output-geoservices')
 const LocalFS = require('koop-localfs')
+const chalk = require('chalk')
+const Table = require('easy-table')
 
 function Koop (config) {
   this.version = pkg.version
@@ -167,8 +169,11 @@ Koop.prototype._initProviderModel = function (provider) {
 Koop.prototype._registerOutput = function (Output) {
   extend(Controller, Output)
   extend(DatasetController, Output)
-
-  this.pluginRoutes = this.pluginRoutes.concat(Output.routes)
+  const routes = Output.routes.map(function (route) {
+    route.output = Output.name
+    return route
+  })
+  this.pluginRoutes = this.pluginRoutes.concat(routes)
   this.log.info('registered output:', Output.name, Output.version)
 }
 
@@ -186,13 +191,48 @@ function extend (klass, extender) {
  * @param {object} server - the koop express server
  */
 function bindRoutes (provider, controller, server, pluginRoutes, options) {
-  bindRouteSet(provider.routes, controller, server, options)
+  bindRouteSet(provider, controller, server, options)
   bindPluginOverrides(provider, controller, server, pluginRoutes, options)
+}
+
+/**
+ * Print provider routes to terminal
+ * @param {string} providerName 
+ * @param {object[]} providerRoutes 
+ */
+function printProviderRoutes (providerName, providerRoutes) {
+  // Print provider routes
+  const table = new Table()
+  providerRoutes.forEach(route => {
+    table.cell(chalk.cyan(`Custom Routes for Provider: ${chalk.white(providerName)}`), chalk.yellow(route.route))
+    table.cell(chalk.cyan(`Methods`), chalk.green(route.methods.toUpperCase()))
+    table.newRow()
+  })
+  console.log(`\n${table.toString()}`)
+}
+
+/**
+ * Print provider plugin routes to terminal
+ * @param {string} providerName 
+ * @param {object} pluginRouteMap 
+ */
+function printPluginRoutes (providerName, pluginRouteMap) {
+  // Print output plugin routes
+  Object.keys(pluginRouteMap).forEach(key => {
+    const table = new Table()
+    pluginRouteMap[key].forEach(route => {
+      table.cell(chalk.cyan(`Routes for Provider: ${chalk.white(providerName)}, Output: ${chalk.white(key)}`), chalk.yellow(route.route))
+      table.cell(chalk.cyan(`Methods`), chalk.green(route.methods.toUpperCase()))
+      table.newRow()
+    })
+    console.log(`\n${table.toString()}`)
+  })
 }
 
 function bindPluginOverrides (provider, controller, server, pluginRoutes, options = {}) {
   const name = provider.namespace || provider.plugin_name || provider.name
   const namespace = name.replace(/\s/g, '').toLowerCase()
+  const pluginRouteMap = {}
   pluginRoutes.forEach(route => {
     let fullRoute = helpers.composeRouteString(route.path, namespace, {
       hosts: provider.hosts,
@@ -200,9 +240,10 @@ function bindPluginOverrides (provider, controller, server, pluginRoutes, option
       absolutePath: route.absolutePath,
       routePrefix: options.routePrefix
     })
+    pluginRouteMap[route.output] = pluginRouteMap[route.output] || []
+    pluginRouteMap[route.output].push({ route: fullRoute, methods: route.methods.join(', ') })
     route.methods.forEach(method => {
       try {
-        console.log(`provider=${provider.name} fullRoute:${fullRoute} ${method.toUpperCase()}`)
         server[method](fullRoute, controller[route.handler].bind(controller))
       } catch (e) {
         console.error(`error=controller does not contain specified method method=${method.toUpperCase()} path=${fullRoute} handler=${route.handler}`)
@@ -210,15 +251,19 @@ function bindPluginOverrides (provider, controller, server, pluginRoutes, option
       }
     })
   })
+  // Print plugin routes to console
+  printPluginRoutes(name, pluginRouteMap)
 }
 
-function bindRouteSet (routes = [], controller, server, options = {}) {
+function bindRouteSet (provider, controller, server, options = {}) {
   const { routePrefix = '' } = options
+  const { routes = [] } = provider
+  const providerRoutes = []
   routes.forEach(route => {
     const routePath = path.posix.join(routePrefix, route.path)
+    providerRoutes.push({ route: routePath, methods: route.methods.join(', ') })
     route.methods.forEach(method => {
       try {
-        console.log(`${routePath} ${method.toUpperCase()}`)
         server[method](routePath, controller[route.handler].bind(controller))
       } catch (e) {
         console.error(`error=controller does not contain specified method method=${method.toUpperCase()} path=${routePath} handler=${route.handler}`)
@@ -226,6 +271,9 @@ function bindRouteSet (routes = [], controller, server, options = {}) {
       }
     })
   })
+  // Print provider routes to terminal
+  const name = provider.namespace || provider.plugin_name || provider.name
+  printProviderRoutes(name, providerRoutes)
 }
 
 /**

--- a/src/index.js
+++ b/src/index.js
@@ -197,8 +197,8 @@ function bindRoutes (provider, controller, server, pluginRoutes, options) {
 
 /**
  * Print provider routes to terminal
- * @param {string} providerName 
- * @param {object[]} providerRoutes 
+ * @param {string} providerName
+ * @param {object[]} providerRoutes
  */
 function printProviderRoutes (providerName, providerRoutes) {
   // Print provider routes
@@ -213,8 +213,8 @@ function printProviderRoutes (providerName, providerRoutes) {
 
 /**
  * Print provider plugin routes to terminal
- * @param {string} providerName 
- * @param {object} pluginRouteMap 
+ * @param {string} providerName
+ * @param {object} pluginRouteMap
  */
 function printPluginRoutes (providerName, pluginRouteMap) {
   // Print output plugin routes
@@ -233,15 +233,17 @@ function bindPluginOverrides (provider, controller, server, pluginRoutes, option
   const name = provider.namespace || provider.plugin_name || provider.name
   const namespace = name.replace(/\s/g, '').toLowerCase()
   const pluginRouteMap = {}
+
   pluginRoutes.forEach(route => {
+    // Compose the full route string from its components
     let fullRoute = helpers.composeRouteString(route.path, namespace, {
       hosts: provider.hosts,
       disableIdParam: provider.disableIdParam,
       absolutePath: route.absolutePath,
       routePrefix: options.routePrefix
     })
-    pluginRouteMap[route.output] = pluginRouteMap[route.output] || []
-    pluginRouteMap[route.output].push({ route: fullRoute, methods: route.methods.join(', ') })
+
+    // Bind the controller to each route
     route.methods.forEach(method => {
       try {
         server[method](fullRoute, controller[route.handler].bind(controller))
@@ -250,18 +252,23 @@ function bindPluginOverrides (provider, controller, server, pluginRoutes, option
         process.exit(1)
       }
     })
+
+    // For each output plugin, keep track of routes, methods
+    pluginRouteMap[route.output] = pluginRouteMap[route.output] || []
+    pluginRouteMap[route.output].push({ route: fullRoute, methods: route.methods.join(', ') })
   })
   // Print plugin routes to console
-  printPluginRoutes(name, pluginRouteMap)
+  if (process.env.NODE_ENV !== 'test') printPluginRoutes(name, pluginRouteMap)
 }
 
 function bindRouteSet (provider, controller, server, options = {}) {
   const { routePrefix = '' } = options
   const { routes = [] } = provider
   const providerRoutes = []
+
   routes.forEach(route => {
     const routePath = path.posix.join(routePrefix, route.path)
-    providerRoutes.push({ route: routePath, methods: route.methods.join(', ') })
+
     route.methods.forEach(method => {
       try {
         server[method](routePath, controller[route.handler].bind(controller))
@@ -270,10 +277,16 @@ function bindRouteSet (provider, controller, server, options = {}) {
         process.exit(1)
       }
     })
+
+    // Keep track of routes, methods
+    providerRoutes.push({ route: routePath, methods: route.methods.join(', ') })
   })
+
   // Print provider routes to terminal
-  const name = provider.namespace || provider.plugin_name || provider.name
-  printProviderRoutes(name, providerRoutes)
+  if (process.env.NODE_ENV !== 'test') {
+    const name = provider.namespace || provider.plugin_name || provider.name
+    printProviderRoutes(name, providerRoutes)
+  }
 }
 
 /**

--- a/src/index.js
+++ b/src/index.js
@@ -37,21 +37,7 @@ function Koop (config) {
 
   const dataset = new Dataset(this)
   const datasetController = new DatasetController(dataset)
-<<<<<<< HEAD
   bindRoutes({ name: 'datasets', routes }, datasetController, this.server, this.pluginRoutes)
-=======
-  bindRouteSet({ name: 'koop-cache', routes }, datasetController, this.server)
-
-  const fsRoutes = routes.concat(geoservices.routes.map(route => {
-    return {
-      path: `/datasets/:id/${route.path}`,
-      handler: route.handler,
-      methods: route.methods
-    }
-  }))
-
-  bindRouteSet({ name: 'koop-cache-geoservices', routes: fsRoutes }, datasetController, this.server)
->>>>>>> Remove lint.
 
   this.status = {
     version: this.version,


### PR DESCRIPTION
Added some organization/pretty printing of registered routes to the console output.  Each provider has two sets of routes: a set of optional "custom" routes that are defined in a provider's `routes.js` file, and a set of routes for each registered output-plugin.  See screengrab below:

![Screen Shot 2019-04-30 at 11 36 01 AM](https://user-images.githubusercontent.com/4369192/56985018-40bf4f00-6b3c-11e9-9ea3-a16462b63a2f.png)


