### PR TITLE
Add compression by default, but allow it to be disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+### Added
+* response compression unless explicitly disabled with config's `disableCompression` property
+
 ## [3.11.1] - 2019-05-22
 ### Changed
 * console logging of provider/output routes

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@koopjs/logger": "^2.0.2",
     "body-parser": "^1.16.0",
     "chalk": "^2.4.2",
+    "compression": "^1.7.4",
     "config": "^3.0.0",
     "cors": "^2.8.1",
     "easy-table": "^1.1.1",

--- a/src/index.js
+++ b/src/index.js
@@ -62,10 +62,10 @@ function initServer (config) {
   const app = express()
   // parse application/json
     .use(bodyParser.json({ limit: '10000kb' }))
-  // parse application/x-www-form-urlencoded
+    // parse application/x-www-form-urlencoded
     .use(bodyParser.urlencoded({ extended: false }))
     .disable('x-powered-by')
-  // TODO this should just live inside featureserver
+    // TODO this should just live inside featureserver
     .use((req, res, next) => {
     // request parameters can come from query url or POST body
       req.query = _.extend(req.query || {}, req.body || {})
@@ -74,14 +74,14 @@ function initServer (config) {
     .use(middleware.paramTrim)
     .use(middleware.paramParse)
     .use(middleware.paramCoerce)
-  // for demos and preview maps in providers
+    // for demos and preview maps in providers
     .set('view engine', 'ejs')
     .use(express.static(path.join(__dirname, '/public')))
     .use(cors())
 
     // Use compression unless explicitly disable in the config
-    if (!config.disableCompression) app.use(compression())
-    return app
+  if (!config.disableCompression) app.use(compression())
+  return app
 }
 
 Koop.prototype.register = function (plugin, options) {

--- a/src/index.js
+++ b/src/index.js
@@ -79,7 +79,7 @@ function initServer (config) {
     .use(express.static(path.join(__dirname, '/public')))
     .use(cors())
 
-    // Use compression unless explicitly disable in the config
+  // Use compression unless explicitly disable in the config
   if (!config.disableCompression) app.use(compression())
   return app
 }

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -11,7 +11,7 @@ describe('Index tests for registering providers', function () {
       const koop = new Koop()
       koop.register(provider)
       const routeCount = (koop.server._router.stack.length)
-      routeCount.should.equal(78)
+      routeCount.should.equal(79)
     })
   })
 


### PR DESCRIPTION
This PR adds compression to all Koop routes by default, unless explicitly disabled with a config property called `disableCompression`.  Koop usage docs need to be updated to explain this.