### PR TITLE
Use config arg for koop.config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+### Changed
+* preferentially use the `config` argument for `this.config` during instantiation
+
 ## [3.12.0] - 2019-05-24
 ### Added
 * response compression unless explicitly disabled with config's `disableCompression` property

--- a/src/index.js
+++ b/src/index.js
@@ -25,13 +25,13 @@ const Table = require('easy-table')
 
 function Koop (config) {
   this.version = pkg.version
-  this.config = require('config')
+  this.config = config || require('config')
   this.server = initServer(this.config)
 
   // default to LocalDB cache
   // cache registration overrides this
   this.cache = new Cache()
-  this.log = new Logger(config)
+  this.log = new Logger(this.config)
   this.pluginRoutes = []
   this.register(geoservices)
   this.register(LocalFS)

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -6,6 +6,13 @@ const request = require('supertest')
 const should = require('should') // eslint-disable-line
 
 describe('Index tests for registering providers', function () {
+  describe('use config argument', function () {
+    it('should register successfully', function () {
+      const koop = new Koop({ foo: 'bar' })
+      koop.config.should.have.property('foo', 'bar')
+    })
+  })
+
   describe('can register a provider', function () {
     it('should register successfully', function () {
       const koop = new Koop()


### PR DESCRIPTION
Preferentially use `config` argument for assignment of `this.config`.  If argument is `undefined`, use `config` module by default.