### PR TITLE
Provide unique cache keys for each provider layer.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+### Added
+* appending layer id to cache key provides unique keys for each layer in a provider
+
 ## [3.12.2] - 2019-06-05
 ### Fixed
 * output-plugins routes must be bound *before* provider routes

--- a/src/models/index.js
+++ b/src/models/index.js
@@ -18,7 +18,9 @@ Model.prototype.pull = function (req, callback) {
 }
 
 function createKey (req) {
-  let key = req.url.split('/')[1]
+  let key = (req.params.layer)
+    ? req.url.split('/')[1] + '_' + req.params.layer
+    : req.url.split('/')[1]
   if (req.params.host) key = [key, req.params.host].join('::')
   if (req.params.id) key = [key, req.params.id].join('::')
   return key

--- a/src/models/index.js
+++ b/src/models/index.js
@@ -18,11 +18,10 @@ Model.prototype.pull = function (req, callback) {
 }
 
 function createKey (req) {
-  let key = (req.params.layer)
-    ? req.url.split('/')[1] + '_' + req.params.layer
-    : req.url.split('/')[1]
+  let key = req.url.split('/')[1]
   if (req.params.host) key = [key, req.params.host].join('::')
   if (req.params.id) key = [key, req.params.id].join('::')
+  if (req.params.layer) key = [key, '_', req.params.layer].join('::')
   return key
 }
 

--- a/src/models/index.js
+++ b/src/models/index.js
@@ -21,7 +21,7 @@ function createKey (req) {
   let key = req.url.split('/')[1]
   if (req.params.host) key = [key, req.params.host].join('::')
   if (req.params.id) key = [key, req.params.id].join('::')
-  if (req.params.layer) key = [key, '_', req.params.layer].join('::')
+  if (req.params.layer) key = [key, req.params.layer].join('::')
   return key
 }
 


### PR DESCRIPTION
Minor change to append the layer ID number to the end of the cache key.