### PR TITLE
Bind provider routes first.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -197,9 +197,9 @@ function extend (klass, extender) {
  * @param {object} server - the koop express server
  */
 function bindRoutes (provider, controller, server, pluginRoutes, options) {
-  // Since plugin-routes are bound first, any routing conflicts will result in requests routed to plugin
-  bindPluginOverrides(provider, controller, server, pluginRoutes, options)
-  bindRouteSet(provider, controller, server, options)
+  // Provider-routes are bound first; any routing conflicts will result in requests routed to provider
+  bindProviderRoutes(provider, controller, server, options)
+  bindPluginRoutes(provider, controller, server, pluginRoutes, options)
 }
 
 /**
@@ -236,7 +236,7 @@ function printPluginRoutes (providerName, pluginRouteMap) {
   })
 }
 
-function bindPluginOverrides (provider, controller, server, pluginRoutes, options = {}) {
+function bindPluginRoutes (provider, controller, server, pluginRoutes, options = {}) {
   const name = provider.namespace || provider.plugin_name || provider.name
   const namespace = name.replace(/\s/g, '').toLowerCase()
   const pluginRouteMap = {}
@@ -270,7 +270,7 @@ function bindPluginOverrides (provider, controller, server, pluginRoutes, option
   if (process.env.NODE_ENV !== 'test') printPluginRoutes(name, pluginRouteMap)
 }
 
-function bindRouteSet (provider, controller, server, options = {}) {
+function bindProviderRoutes (provider, controller, server, options = {}) {
   const { routePrefix = '' } = options
   const { routes = [] } = provider
   const providerRoutes = {}

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -35,7 +35,7 @@ describe('Index tests for registering providers', function () {
         .map(layer => { return _.get(layer, 'route.path') })
       const pluginRouteIndex = routePaths.findIndex(path => path.includes('/test-provider/:id/FeatureServer'))
       const providerRouteIndex = routePaths.findIndex(path => path.includes('/fake/:id'))
-      providerRouteIndex.should.be.above(pluginRouteIndex)
+      providerRouteIndex.should.be.below(pluginRouteIndex)
     })
   })
 

--- a/test/middleware-test.js
+++ b/test/middleware-test.js
@@ -1,5 +1,6 @@
-const middleware = require('../src/middleware')
+const _ = require('lodash')
 const should = require('should') // eslint-disable-line
+const middleware = require('../src/middleware')
 
 describe('Middleware tests', function () {
   describe('paramTrim function', function () {
@@ -20,13 +21,13 @@ describe('Middleware tests', function () {
     it('should convert a JSON (escaped) string parameter to a JSON object', function () {
       const req = { query: { param1: '{\"jsonstr\":\"foobar\"}' } } // eslint-disable-line
       middleware.paramParse(req, {}, function () {})
-      req.query.param1.jsonstr.should.equal('foobar')
+      _.get(req, 'query.param1.jsonstr').should.equal('foobar')
     })
 
     it('should convert a JSON string parameter to a JSON object', function () {
       const req = { query: { param1: '{"jsonstr":"foobar"}' } }
       middleware.paramParse(req, {}, function () {})
-      req.query.param1.jsonstr.should.equal('foobar')
+      _.get(req, 'query.param1.jsonstr').should.equal('foobar')
     })
   })
 


### PR DESCRIPTION
Change order of route binding; provider routes first, then plugin routes.  This allows custom routes on provider to supersede any similarly named routes defined by plugins.  This is a beneficial feature because it allows a provider author to add routes with an output-plugin signature that may not yet be supported by the plugin. For example, koop-output-geoservices does not yet support an `addFeatures` method/route.  But a provider could define such a route, e.g., `/provider/:id/FeatureServer/:layer/addFeatures`.  By binding this route first, we ensure that requests don't get sent to the `koop-output-geoservices` regexed route, i.e., `/provider/:id/FeatureServer/:layer/:method`.