### PR TITLE
Refactor attachment of options to provider Models.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -156,16 +156,17 @@ Koop.prototype._registerProvider = function (provider, options = {}) {
 
 Koop.prototype._initProviderModel = function (provider, options) {
   function ThisModel (koop) {
-    this.cache = koop.cache
-    ThisModel.super_.call(this, koop)
+    this.cache = options.cache || koop.cache
+
+    // Merging the koop object into options to preserve backward compatibility; consider removing in Koop 4.x
+    this.options = _.chain(options).omit(options, 'cache').assign(koop).value()
+    ThisModel.super_.call(this, options)
   }
 
   extend(ThisModel, Model)
   Util.inherits(ThisModel, provider.Model)
 
-  const model = new ThisModel(this)
-  model.options = options
-  return model
+  return new ThisModel(this)
 }
 
 /**

--- a/src/index.js
+++ b/src/index.js
@@ -154,7 +154,7 @@ Koop.prototype._registerProvider = function (provider, options = {}) {
   this.log.info('registered provider:', name, provider.version)
 }
 
-Koop.prototype._initProviderModel = function (provider, options) {
+Koop.prototype._initProviderModel = function (provider, options = {}) {
   function ThisModel (koop) {
     this.cache = options.cache || koop.cache
 

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -27,10 +27,12 @@ describe('Index tests for registering providers', function () {
       providerPath.should.not.equal(undefined)
     })
 
-    it('should register successfully and attach options object to Model instance', function () {
+    it('should register successfully and attach cache and options object to Model instance', function () {
       const koop = new Koop()
       koop.register(provider, { name: 'value' })
-      koop.controllers['test-provider'].model.should.have.property('options', { name: 'value' })
+      koop.controllers['test-provider'].model.should.have.property('cache')
+      koop.controllers['test-provider'].model.should.have.property('options')
+      koop.controllers['test-provider'].model.options.should.have.property('name', 'value')
     })
 
     it('should register plugin-routes before provider-routes', function () {


### PR DESCRIPTION
A cleaner pattern for attaching the options object to a Model instance. Current pattern passes the `koop` instance to the Model constructor as the `options` argument.  Rationale for that is unclear.

This PR:
* changes that pattern so that the `options` object that arrives during registration is passed into the Model constructor.
* uses the `options.cache` preferentially
* merges the `options` and `koop` objects before passing into the Model constructor.  This is done to preserve backwards compatibility for any providers that are expecting the `koop` object to get passed into the constructor

