### PR TITLE
Add "before", "after" and "name" options.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 * Add options object to instantiated model
 * Add cache option validiation
+* Add `before` and `after` transformation functions to provider registration options
+* Add `name` to provider registration options and preferentially use as provider name in routes
 
 ## [3.16.0] - 2019-12-17
 ### Added

--- a/src/index.js
+++ b/src/index.js
@@ -29,7 +29,10 @@ const providerOptionsSchema = Joi.object({
     retrieve: Joi.function().arity(3).required(),
     upsert: Joi.function().arity(3).required()
   }).unknown(true).optional(),
-  routePrefix: Joi.string().optional()
+  routePrefix: Joi.string().optional(),
+  before: Joi.function().arity(2).optional(),
+  after: Joi.function().arity(3).optional(),
+  name: Joi.string().optional()
 }).unknown(true)
 
 function Koop (config) {
@@ -148,7 +151,7 @@ Koop.prototype._registerProvider = function (provider, options = {}) {
   } else {
     controller = new Controller(model)
   }
-  const name = provider.pluginName || provider.plugin_name || provider.name
+  const name = options.name || provider.pluginName || provider.plugin_name || provider.name
   this.controllers[name] = controller
   provider.version = provider.version || '(version missing)'
 
@@ -168,9 +171,11 @@ Koop.prototype._registerProvider = function (provider, options = {}) {
 Koop.prototype._initProviderModel = function (provider, options = {}) {
   function ThisModel (koop) {
     this.cache = options.cache || koop.cache
+    this.before = options.before
+    this.after = options.after
 
     // Merging the koop object into options to preserve backward compatibility; consider removing in Koop 4.x
-    this.options = _.chain(options).omit(options, 'cache').assign(koop).value()
+    this.options = _.chain(options).omit(options, 'cache', 'before', 'after').assign(koop).value()
     ThisModel.super_.call(this, options)
   }
 


### PR DESCRIPTION
This PR:
1. adds _transformation_ functions to the Koop data flow.
* A `before` function is fired before the the Model's `getData` and allows the modification of the `request` object.
* An `after` function is fired after the Model's `getData` function and allows modification of the data payload as well as further modification of the `request` object.
Transformation function will allow user to leverage published providers with custom manipulation without having to fork the original provider code.  For example, a user could use the Github provider to access datasets in non-WGS84 coordinate systems, but have the `after` function reproject the data to WGS84 before sending it on to koop-core.

2. preferentially uses the `name` option from provider registration for the provider routes.  This allows multiple registrations of the same provider without route conflicts.  This may be desired if a developer wishes to use the same provider but with different transformation function.