### PR TITLE
Ensure provider option 'name' is used in routes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+### Fixed
+* Provider name option gets used for plugin routes
+
 ## [3.17.0] - 2020-01-14
 ### Added
 * Add options object to instantiated model

--- a/src/index.js
+++ b/src/index.js
@@ -151,7 +151,7 @@ Koop.prototype._registerProvider = function (provider, options = {}) {
   } else {
     controller = new Controller(model)
   }
-  const name = options.name || provider.pluginName || provider.plugin_name || provider.name
+  const name = getProviderName(provider, options)
   this.controllers[name] = controller
   provider.version = provider.version || '(version missing)'
 
@@ -256,7 +256,7 @@ function printPluginRoutes (providerName, pluginRouteMap) {
 }
 
 function bindPluginRoutes (provider, controller, server, pluginRoutes, options = {}) {
-  const name = options.name || provider.namespace || provider.pluginName || provider.plugin_name || provider.name
+  const name = getProviderName(provider, options)
   const namespace = name.replace(/\s/g, '').toLowerCase()
   const pluginRouteMap = {}
 
@@ -366,6 +366,10 @@ Koop.prototype._registerPlugin = function (Plugin) {
 function validateAgainstSchema (params, schema, prefix) {
   const result = schema.validate(params)
   if (result.error) throw new Error(`${prefix} ${result.error}`)
+}
+
+function getProviderName (provider, options) {
+  return options.name || provider.namespace || provider.pluginName || provider.plugin_name || provider.name
 }
 
 module.exports = Koop

--- a/src/index.js
+++ b/src/index.js
@@ -256,7 +256,7 @@ function printPluginRoutes (providerName, pluginRouteMap) {
 }
 
 function bindPluginRoutes (provider, controller, server, pluginRoutes, options = {}) {
-  const name = provider.namespace || provider.pluginName || provider.plugin_name || provider.name
+  const name = options.name || provider.namespace || provider.pluginName || provider.plugin_name || provider.name
   const namespace = name.replace(/\s/g, '').toLowerCase()
   const pluginRouteMap = {}
 

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -138,6 +138,13 @@ describe('Index tests for registering providers', function () {
         name: 'options-name'
       })
       koop.controllers.should.have.property('options-name').and.be.a.instanceOf(Controller)
+      koop.controllers.should.have.property('options-name').and.be.a.instanceOf(Controller)
+      // Check that the stack includes routes with the provider name in the path
+      const providerPath = koop.server._router.stack
+        .filter((layer) => { return _.has(layer, 'route.path') })
+        .map(layer => { return _.get(layer, 'route.path') })
+        .find(path => path.includes('options-name'))
+      providerPath.should.not.equal(undefined)
     })
   })
 


### PR DESCRIPTION
The new `name` option was not being preferentially used in plugin route definition.  Fixed here.