### PR TITLE
Fix bug in tracking of registered routes.

### DIFF
--- a/src/helpers/register-plugin-routes.js
+++ b/src/helpers/register-plugin-routes.js
@@ -6,7 +6,7 @@ function registerProviderRoutes ({ provider, controller, server, pluginRoutes },
   const namespace = provider.namespace.replace(/\s/g, '').toLowerCase()
   const { hosts, disableIdParam } = provider
   const { routePrefix } = options
-  const pluginRouteMap = {}
+  const routeMap = {}
 
   pluginRoutes.forEach(route => {
     const { path, methods, absolutePath, output } = route
@@ -27,10 +27,10 @@ function registerProviderRoutes ({ provider, controller, server, pluginRoutes },
     })
 
     // For each output plugin, keep track of routes, methods
-    _.set(pluginRouteMap, `${output}.${routeString}`, methods)
+    addMethodsToRouteMap(routeMap, `${output}.${routeString}`, methods)
   })
 
-  return pluginRouteMap
+  return routeMap
 }
 
 function bindController (params) {
@@ -51,6 +51,11 @@ function registerRoutes (params) {
   methods.forEach(method => {
     server[method.toLowerCase()](routeString, controller)
   })
+}
+
+function addMethodsToRouteMap (map, path, methods) {
+  const existingMethods = _.get(map, path, [])
+  _.set(map, path, _.concat(existingMethods, methods))
 }
 
 module.exports = registerProviderRoutes

--- a/test/helpers/register-plugin-routes.spec.js
+++ b/test/helpers/register-plugin-routes.spec.js
@@ -4,7 +4,8 @@ require('should-sinon')
 const registerPluginRoutes = require('../../src/helpers/register-plugin-routes')
 
 const mockController = {
-  testHandler: () => {}
+  testHandler: () => {},
+  testHandler2: () => {}
 }
 
 const mockProvider = {
@@ -14,13 +15,15 @@ const mockProvider = {
 }
 
 const mockPluginRoutes = [
-  { output: 'MockOutput', path: '/output-plugin', methods: ['get'], handler: 'testHandler' }
+  { output: 'MockOutput', path: '/output-plugin', methods: ['get'], handler: 'testHandler' },
+  { output: 'MockOutput', path: '/output-plugin', methods: ['post'], handler: 'testHandler2' }
 ]
 
 describe('Tests for register-plugin-routes', function () {
   it('should register a plugin route, lowercased', () => {
     const mockServer = sinon.spy({
-      get: () => {}
+      get: () => {},
+      post: () => {}
     })
 
     const pluginRouteMap = registerPluginRoutes({
@@ -33,18 +36,20 @@ describe('Tests for register-plugin-routes', function () {
     mockServer.get.should.be.calledOnce()
     pluginRouteMap.should.deepEqual({
       MockOutput: {
-        '/mock-provider/:host/:id/output-plugin': ['get']
+        '/mock-provider/:host/:id/output-plugin': ['get', 'post']
       }
     })
   })
 
   it('should register a plugin route, uppercased', () => {
     const mockPluginRoutes = [
-      { output: 'MockOutput', path: '/output-plugin', methods: ['GET'], handler: 'testHandler' }
+      { output: 'MockOutput', path: '/output-plugin', methods: ['GET'], handler: 'testHandler' },
+      { output: 'MockOutput', path: '/output-plugin', methods: ['POST'], handler: 'testHandler2' }
     ]
 
     const mockServer = sinon.spy({
-      get: () => {}
+      get: () => {},
+      post: () => {}
     })
 
     const pluginRouteMap = registerPluginRoutes({
@@ -57,7 +62,7 @@ describe('Tests for register-plugin-routes', function () {
     mockServer.get.should.be.calledOnce()
     pluginRouteMap.should.deepEqual({
       MockOutput: {
-        '/mock-provider/:host/:id/output-plugin': ['GET']
+        '/mock-provider/:host/:id/output-plugin': ['GET', 'POST']
       }
     })
   })

--- a/test/helpers/register-provider-routes.spec.js
+++ b/test/helpers/register-provider-routes.spec.js
@@ -4,13 +4,15 @@ require('should-sinon')
 const registerProviderRoutes = require('../../src/helpers/register-provider-routes')
 
 const mockController = {
-  testHandler: () => {}
+  testHandler: () => {},
+  testHandler2: () => {}
 }
 
 describe('Tests for register-provider-routes, lowercased', function () {
   it('should register a provider route', () => {
     const mockServer = sinon.spy({
-      get: () => {}
+      get: () => {},
+      post: () => {}
     })
 
     const mockProvider = {
@@ -21,6 +23,11 @@ describe('Tests for register-provider-routes, lowercased', function () {
         path: '/test/route',
         methods: ['get'],
         handler: 'testHandler'
+      },
+      {
+        path: '/test/route',
+        methods: ['post'],
+        handler: 'testHandler2'
       }]
     }
     const providerRouteMap = registerProviderRoutes({
@@ -30,7 +37,7 @@ describe('Tests for register-provider-routes, lowercased', function () {
     })
 
     mockServer.get.should.be.calledOnce()
-    providerRouteMap.should.deepEqual({ '/test/route': ['get'] })
+    providerRouteMap.should.deepEqual({ '/test/route': ['get', 'post'] })
   })
 
   it('should register a provider route, uppercased', () => {


### PR DESCRIPTION
Found a bug is the way registered routes are track in the route-map objects; this didn't affect functionality, just the console output that prints route-paths and methods.