### PR TITLE
Patch model registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 ### Fixed
-* Change order of cache and options assignment to maintain backward compatability
+* Prevent overwriting cache and option assignments that occur in provider model constructors
 
 ## [3.17.2] - 2020-03-26
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+### Fixed
+* Change order of cache and options assignment to maintain backward compatability
+
 ## [3.17.2] - 2020-03-26
 ### Added
 * New functions to support fetching metadata for data catalog and layer

--- a/src/models/extended-model.js
+++ b/src/models/extended-model.js
@@ -10,6 +10,7 @@ module.exports = class ExtendedModel {
         // Merging the koop object into options to preserve backward compatibility; consider removing in Koop 4.x
         const modelOptions = _.chain(options).omit(options, 'cache', 'before', 'after').assign(koop).value()
         super(modelOptions)
+        // Provider constructor's may assign values to this.cache and this.options; so check before assigning defaults
         if (!this.cache) this.cache = options.cache || koop.cache
         if (!this.options) this.options = modelOptions
         this.before = options.before

--- a/src/models/extended-model.js
+++ b/src/models/extended-model.js
@@ -10,10 +10,10 @@ module.exports = class ExtendedModel {
         // Merging the koop object into options to preserve backward compatibility; consider removing in Koop 4.x
         const modelOptions = _.chain(options).omit(options, 'cache', 'before', 'after').assign(koop).value()
         super(modelOptions)
-        this.cache = options.cache || koop.cache
+        if (!this.cache) this.cache = options.cache || koop.cache
+        if (!this.options) this.options = modelOptions
         this.before = options.before
         this.after = options.after
-        this.options = modelOptions
       }
 
       pull (req, callback) {


### PR DESCRIPTION
Prevent overwriting cache and option assignments that occur in provider model constructors