### PR TITLE
Add route precedence option.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+### Added option to allow output routes to be registered before provider routes; if true any conflicts will default to output routes
+
 ## [3.17.3] - 2020-03-26
 ### Fixed
 * Prevent overwriting cache and option assignments that occur in provider model constructors

--- a/src/helpers/register-plugin-routes.js
+++ b/src/helpers/register-plugin-routes.js
@@ -2,7 +2,7 @@ const _ = require('lodash')
 const validateHttpMethods = require('./validate-http-methods')
 const composeRouteString = require('./compose-route-string')
 
-function registerProviderRoutes ({ provider, controller, server, pluginRoutes }, options = {}) {
+function registerPluginRoutes ({ provider, controller, server, pluginRoutes }, options = {}) {
   const namespace = provider.namespace.replace(/\s/g, '').toLowerCase()
   const { hosts, disableIdParam } = provider
   const { routePrefix } = options
@@ -58,4 +58,4 @@ function addMethodsToRouteMap (map, path, methods) {
   _.set(map, path, _.concat(existingMethods, methods))
 }
 
-module.exports = registerProviderRoutes
+module.exports = registerPluginRoutes

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -41,6 +41,18 @@ describe('Index tests for registering providers', function () {
       providerRouteIndex.should.be.below(pluginRouteIndex)
     })
 
+    it('should register plugin-routes before provider-routes', function () {
+      const koop = new Koop()
+      koop.register(_.cloneDeep(provider), { defaultToOutputRoutes: true })
+      // Check that the stack index of the plugin routes are prior to index of provider routes
+      const routePaths = koop.server._router.stack
+        .filter((layer) => { return _.has(layer, 'route.path') })
+        .map(layer => { return _.get(layer, 'route.path') })
+      const pluginRouteIndex = routePaths.findIndex(path => path.includes('/test-provider/:id/FeatureServer'))
+      const providerRouteIndex = routePaths.findIndex(path => path.includes('/fake/:id'))
+      pluginRouteIndex.should.be.below(providerRouteIndex)
+    })
+
     it('should register successfully and attach cache and options object to model', function () {
       const koop = new Koop()
       koop.register(_.cloneDeep(provider), { routePrefix: 'path-to-route' })


### PR DESCRIPTION
When a provider is registered, a provider's custom routes are registered first, followed by provider-namespaced output routes.  This ordering means that in the event of any route path collisions, the provider's custom routes will be used. This is intentional and was introduced in resposne to https://github.com/koopjs/koop-core/issues/88.

Some implementations may want or require the opposite, i.e., output routes registered first.  This PR adds a new provider registration option `defaultToOutputRoutes` which allows output routes to be registered first.  In the event of collisions, the output route is given precedence over the provider custom route.  The default value of this new option is `false`.