### PR TITLE
Move datasets provider to its own directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+### Changed
+* moved datasets provider to its own directory and leverage the registration function
+
+### Fixed
+* path construction when no host or id parameter
+
 ## [3.19.0-alpha.0] - 2020-06-08
 ### Changed
 * Refactored provider registration, output registration, and controller treatment.

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ const _ = require('lodash')
 const Joi = require('@hapi/joi')
 const Cache = require('koop-cache-memory')
 const Logger = require('@koopjs/logger')
-const datasetRoutes = require('./lib/datasets/routes')
+const datasetsProvider = require('./lib/datasets')
 const {
   bindAuthMethods
 } = require('./lib/helpers')
@@ -47,6 +47,7 @@ function Koop (config) {
   this.outputs = []
   this.register(geoservices)
   this.register(LocalFS)
+  this.register(datasetsProvider)
   this.status = {
     version: this.version,
     providers: {}
@@ -57,16 +58,6 @@ function Koop (config) {
       this.log.info(`Koop ${this.version} mounted at ${this.server.mountpath}`)
     })
     .get('/status', (req, res) => res.json(this.status))
-
-  this.providers.push(ProviderRegistration.create({
-    koop: this,
-    provider: {
-      namespace: 'datasets',
-      routes: datasetRoutes,
-      Model: require('./lib/datasets/model'),
-      Controller: require('./lib/datasets/controller')
-    }
-  }))
 }
 
 Util.inherits(Koop, Events)

--- a/lib/datasets/index.js
+++ b/lib/datasets/index.js
@@ -1,0 +1,10 @@
+const provider = {
+  type: 'provider',
+  name: 'datasets',
+  hosts: false,
+  Model: require('./model'),
+  routes: require('./routes'),
+  Controller: require('./controller')
+}
+
+module.exports = provider

--- a/lib/helpers/namespaced-route-path.js
+++ b/lib/helpers/namespaced-route-path.js
@@ -8,7 +8,6 @@ function namespacedRoutePath (params) {
     disableIdParam,
     routePrefix = '',
     namespace = '',
-
     absolutePath,
     path
 
@@ -31,6 +30,7 @@ function getKoopParams (hosts, disableIdParam) {
   if (hosts && !disableIdParam) return ':host/:id'
   else if (hosts && disableIdParam) return ':host'
   else if (!disableIdParam) return ':id'
+  else return ''
 }
 
 module.exports = namespacedRoutePath

--- a/test/datasets/index.spec.js
+++ b/test/datasets/index.spec.js
@@ -1,7 +1,7 @@
-const Koop = require('../')
+const Koop = require('../../')
 const koop = new Koop()
 const request = require('supertest')
-const geojson = require('./fixtures/snow.json')
+const geojson = require('../fixtures/snow.json')
 const should = require('should') // eslint-disable-line
 
 describe('Datsets API', function () {


### PR DESCRIPTION
1. Move datasets provider to its own directory
2. Use register function for datasets
3. fix bug in route construction when no `host` or `id` params