### PR TITLE
console printing bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 ### Fixed
-* Add ENV `KOOP_CONSOLE_ROUTES=suppress` to suppress console route logging.
+* Add ENV `KOOP_DISABLE_CONSOLE_ROUTES=true` to suppress console route logging.
 
 ## [3.18.0] - 2020-03-31
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+### Fixed
+* Add ENV `KOOP_CONSOLE_ROUTES=suppress` to suppress console route logging.
+
 ## [3.18.0] - 2020-03-31
 ### Added
 * Option to allow output routes to be registered before provider routes; if true any conflicts will default to output routes

--- a/src/helpers/console-printing.js
+++ b/src/helpers/console-printing.js
@@ -2,7 +2,7 @@ const chalk = require('chalk')
 const Table = require('easy-table')
 
 module.exports = function (namespace, routes) {
-  if (process.env.NODE_ENV === 'test' || process.env.KOOP_CONSOLE_ROUTES === 'suppress') { return }
+  if (process.env.NODE_ENV === 'test' || process.env.KOOP_DISABLE_CONSOLE_ROUTES === 'true') { return }
 
   const { providerRouteMap, pluginRouteMap } = routes
   printProviderRoutes(namespace, providerRouteMap)

--- a/src/helpers/console-printing.js
+++ b/src/helpers/console-printing.js
@@ -2,7 +2,7 @@ const chalk = require('chalk')
 const Table = require('easy-table')
 
 module.exports = function (namespace, routes) {
-  if (process.env.NODE_ENV === 'test') return
+  if (process.env.NODE_ENV === 'test' || process.env.KOOP_CONSOLE_ROUTES === 'suppress') { return }
 
   const { providerRouteMap, pluginRouteMap } = routes
   printProviderRoutes(namespace, providerRouteMap)


### PR DESCRIPTION
Any route definitions that include `[...]` fragment cause an error in console printing of registered routes.  This PR adds an ENV options to disable console printing as a workaround; more permanent fix to follow.