### PR TITLE
Refactor the Model pull method

### DIFF
--- a/lib/provider-registration/create-model.js
+++ b/lib/provider-registration/create-model.js
@@ -45,7 +45,7 @@ module.exports = function createModel ({ ProviderModel, koop, namespace }, optio
 
     // TODO: the pullLayer() and the pullCatalog() are very similar to the pull()
     // function. We may consider to merging them in the future.
-    async pullLayer (req, callback) {
+    pullLayer (req, callback) {
       const key = (this.createKey) ? this.createKey(req) : createKey(req)
       const layerKey = `${key}::layer`
       this.cache.retrieve(layerKey, req.query, (err, cached) => {

--- a/lib/provider-registration/create-model.js
+++ b/lib/provider-registration/create-model.js
@@ -1,12 +1,14 @@
 const { promisify } = require('util')
 const _ = require('lodash')
-const before = (req, next) => { next() }
-const after = (req, data, callback) => { callback(null, data) }
+const before = (req, callback) => { callback() }
+const after = (req, data, callback) => {
+  callback(null, data)
+}
 
 module.exports = function createModel ({ ProviderModel, koop, namespace }, options = {}) {
   class Model extends ProviderModel {
     constructor (koop, options) {
-      // Merging the koop object into options to preserve backward compatibility; consider removing in Koop 4.x
+      // Merging the koop object into options to preserve backward compatibility; consider removing in future major release
       const modelOptions = _.chain(options).omit(options, 'cache', 'before', 'after').assign(koop).value()
       super(modelOptions)
       // Provider constructor's may assign values to this.cache and this.options; so check before assigning defaults
@@ -16,23 +18,27 @@ module.exports = function createModel ({ ProviderModel, koop, namespace }, optio
       this.after = promisify(options.after || after)
       this.cacheRetrieve = promisify(this.cache.retrieve).bind(this.cache)
       this.cacheUpsert = promisify(this.cache.upsert).bind(this.cache)
+      this.getData = promisify(this.getData).bind(this)
     }
 
     async pull (req, callback) {
       const key = (this.createKey) ? this.createKey(req) : createKey(req)
       const dataKey = `${key}::data`
-      const getData = promisify(this.getData).bind(this)
+
       try {
         const cached = await this.cacheRetrieve(dataKey, req.query)
         if (isFresh(cached)) return callback(null, cached)
       } catch (err) {
-        console.log(err)
+        if (process.env.KOOP_LOG_LEVEL === 'debug') {
+          console.log(err)
+        }
       }
       try {
-        await before(req)
-        const providerGeojson = await getData(req)
-        const afterFuncGeojson = await after(req, providerGeojson)
-        await this.cacheUpsert(dataKey, providerGeojson, { ttl: providerGeojson.ttl })
+        // TODO: authentication should go here
+        await this.before(req)
+        const providerGeojson = await this.getData(req)
+        const afterFuncGeojson = await this.after(req, providerGeojson)
+        this.cacheUpsert(dataKey, providerGeojson, { ttl: providerGeojson.ttl })
         callback(null, afterFuncGeojson)
       } catch (err) {
         callback(err)
@@ -41,7 +47,7 @@ module.exports = function createModel ({ ProviderModel, koop, namespace }, optio
 
     // TODO: the pullLayer() and the pullCatalog() are very similar to the pull()
     // function. We may consider to merging them in the future.
-    pullLayer (req, callback) {
+    async pullLayer (req, callback) {
       const key = (this.createKey) ? this.createKey(req) : createKey(req)
       const layerKey = `${key}::layer`
       this.cache.retrieve(layerKey, req.query, (err, cached) => {

--- a/lib/provider-registration/create-model.js
+++ b/lib/provider-registration/create-model.js
@@ -1,3 +1,4 @@
+const { promisify } = require('util')
 const _ = require('lodash')
 const before = (req, next) => { next() }
 const after = (req, data, callback) => { callback(null, data) }
@@ -11,32 +12,31 @@ module.exports = function createModel ({ ProviderModel, koop, namespace }, optio
       // Provider constructor's may assign values to this.cache and this.options; so check before assigning defaults
       if (!this.cache) this.cache = options.cache || koop.cache
       if (!this.options) this.options = modelOptions
-      this.before = options.before
-      this.after = options.after
+      this.before = promisify(options.before || before)
+      this.after = promisify(options.after || after)
+      this.cacheRetrieve = promisify(this.cache.retrieve).bind(this.cache)
+      this.cacheUpsert = promisify(this.cache.upsert).bind(this.cache)
     }
 
-    pull (req, callback) {
+    async pull (req, callback) {
       const key = (this.createKey) ? this.createKey(req) : createKey(req)
       const dataKey = `${key}::data`
-      this.before = this.before || before.bind(this)
-      this.after = this.after || after.bind(this)
-      this.cache.retrieve(dataKey, req.query, (err, cached) => {
-        if (!err && isFresh(cached)) {
-          callback(null, cached)
-        } else {
-          this.before(req, (err) => {
-            if (err) return callback(err)
-            this.getData(req, (err, data) => {
-              if (err) return callback(err)
-              this.after(req, data, (err, data) => {
-                if (err) return callback(err)
-                callback(null, data)
-                if (data.ttl) this.cache.upsert(dataKey, data, { ttl: data.ttl })
-              })
-            })
-          })
-        }
-      })
+      const getData = promisify(this.getData).bind(this)
+      try {
+        const cached = await this.cacheRetrieve(dataKey, req.query)
+        if (isFresh(cached)) return callback(null, cached)
+      } catch (err) {
+        console.log(err)
+      }
+      try {
+        await before(req)
+        const providerGeojson = await getData(req)
+        const afterFuncGeojson = await after(req, providerGeojson)
+        await this.cacheUpsert(dataKey, providerGeojson, { ttl: providerGeojson.ttl })
+        callback(null, afterFuncGeojson)
+      } catch (err) {
+        callback(err)
+      }
     }
 
     // TODO: the pullLayer() and the pullCatalog() are very similar to the pull()

--- a/lib/provider-registration/create-model.js
+++ b/lib/provider-registration/create-model.js
@@ -1,9 +1,7 @@
 const { promisify } = require('util')
 const _ = require('lodash')
 const before = (req, callback) => { callback() }
-const after = (req, data, callback) => {
-  callback(null, data)
-}
+const after = (req, data, callback) => { callback(null, data) }
 
 module.exports = function createModel ({ ProviderModel, koop, namespace }, options = {}) {
   class Model extends ProviderModel {

--- a/test/fixtures/fake-provider-ii/models/fake.js
+++ b/test/fixtures/fake-provider-ii/models/fake.js
@@ -4,4 +4,11 @@ function Fake () {
   }
 }
 
+Fake.prototype.getData = function getData (req, callback) {
+  callback(null, {
+    type: 'FeatureCollection',
+    features: []
+  })
+}
+
 module.exports = Fake

--- a/test/fixtures/fake-provider/models/fake.js
+++ b/test/fixtures/fake-provider/models/fake.js
@@ -2,13 +2,12 @@ function Fake () {
   this.find = function find (id, options, callback) {
     callback(null, [{}])
   }
-
-  this.getData = function getData (req, callback) {
-    callback(null, {
-      type: 'FeatureCollection',
-      features: []
-    })
-  }
 }
 
+Fake.prototype.getData = function getData (req, callback) {
+  callback(null, {
+    type: 'FeatureCollection',
+    features: []
+  })
+}
 module.exports = Fake

--- a/test/provider-registration/create-model.spec.js
+++ b/test/provider-registration/create-model.spec.js
@@ -1,6 +1,7 @@
 /* eslint handle-callback-err: "off" */
 const should = require('should') // eslint-disable-line
 const sinon = require('sinon')
+const { promisify} = require('util')
 require('should-sinon')
 const _ = require('lodash')
 const providerMock = require('../fixtures/fake-provider')
@@ -9,30 +10,33 @@ const koopMock = { test: 'value' }
 
 describe('Tests for create-model', function () {
   describe('createKey', function () {
-    it('should create cache-key as provider name', () => {
+    it.only('should create cache-key as provider name', (done) => {
       const retrieveSpy = sinon.spy(function (key, queryParams, callback) {
         callback(null, {})
       })
-      const pullSpy = sinon.spy()
+      const pullSpy = sinon.spy(() => {
+        retrieveSpy.should.be.calledOnce()
+        retrieveSpy.firstCall.args.length.should.equal(3)
+        retrieveSpy.firstCall.args[0].should.equal('test-provider::data')
+        retrieveSpy.firstCall.args[1].should.be.an.Object().and.be.empty()
+        retrieveSpy.firstCall.args[2].should.be.an.Function()
+        pullSpy.should.be.calledOnce()
+        pullSpy.firstCall.args.length.should.equal(2)
+        pullSpy.firstCall.args.should.deepEqual([null, {}])
+        done()
+      })
 
       // create a model with mocked cache "retrieve" function
       const model = createModel({ ProviderModel: providerMock.Model, koop: koopMock }, {
         cache: {
-          retrieve: retrieveSpy
+          retrieve: retrieveSpy,
+          upsert: () => {}
         }
       })
 
       model.pull({ url: 'domain/test-provider', params: {}, query: {} }, pullSpy)
 
-      retrieveSpy.should.be.calledOnce()
-      retrieveSpy.firstCall.args.length.should.equal(3)
-      retrieveSpy.firstCall.args[0].should.equal('test-provider::data')
-      retrieveSpy.firstCall.args[1].should.be.an.Object().and.be.empty()
-      retrieveSpy.firstCall.args[2].should.be.an.Function()
-      pullSpy.should.be.calledOnce()
-      pullSpy.firstCall.args.length.should.equal(2)
-      should.not.exist(pullSpy.firstCall.args[0])
-      pullSpy.firstCall.args[1].should.be.an.Object().and.be.empty()
+
     })
 
     it('should create cache-key as provider name and concenated url params', () => {

--- a/test/provider-registration/create-model.spec.js
+++ b/test/provider-registration/create-model.spec.js
@@ -1,7 +1,7 @@
+/* eslint-env mocha */
 /* eslint handle-callback-err: "off" */
-const should = require('should') // eslint-disable-line
+const should = require('should')
 const sinon = require('sinon')
-const { promisify} = require('util')
 require('should-sinon')
 const _ = require('lodash')
 const providerMock = require('../fixtures/fake-provider')
@@ -9,22 +9,54 @@ const createModel = require('../../lib/provider-registration/create-model')
 const koopMock = { test: 'value' }
 
 describe('Tests for create-model', function () {
+  describe('model pull method', () => {
+    it('should work in callback form, all methods called', (done) => {
+      const beforeSpy = sinon.spy((req, beforeCallback) => {
+        beforeCallback()
+      })
+
+      const afterSpy = sinon.spy(function (req, data, callback) {
+        callback(null, data)
+      })
+
+      const cacheRetrieveSpy = sinon.spy((key, query, callback) => {
+        callback(new Error('no cache'))
+      })
+
+      const cacheUpsertSpy = sinon.spy(() => {})
+
+      const getDataSpy = sinon.spy(function (req, callback) {
+        callback(null, { metadata: {} })
+      })
+
+      class Model extends providerMock.Model {}
+      Model.prototype.getData = getDataSpy
+      const model = createModel({ ProviderModel: Model, koop: koopMock }, {
+        cache: {
+          retrieve: cacheRetrieveSpy,
+          upsert: cacheUpsertSpy
+        },
+        before: beforeSpy,
+        after: afterSpy
+      })
+
+      model.pull({ url: 'domain/test-provider', params: {}, query: {} }, function (err, data) {
+        cacheRetrieveSpy.calledOnce.should.equal(true)
+        beforeSpy.calledOnce.should.equal(true)
+        getDataSpy.calledOnce.should.equal(true)
+        afterSpy.calledOnce.should.equal(true)
+        cacheUpsertSpy.calledOnce.should.equal(true)
+        done()
+      })
+    })
+  })
+
   describe('createKey', function () {
-    it.only('should create cache-key as provider name', (done) => {
+    it('should create cache-key as provider name', async () => {
       const retrieveSpy = sinon.spy(function (key, queryParams, callback) {
         callback(null, {})
       })
-      const pullSpy = sinon.spy(() => {
-        retrieveSpy.should.be.calledOnce()
-        retrieveSpy.firstCall.args.length.should.equal(3)
-        retrieveSpy.firstCall.args[0].should.equal('test-provider::data')
-        retrieveSpy.firstCall.args[1].should.be.an.Object().and.be.empty()
-        retrieveSpy.firstCall.args[2].should.be.an.Function()
-        pullSpy.should.be.calledOnce()
-        pullSpy.firstCall.args.length.should.equal(2)
-        pullSpy.firstCall.args.should.deepEqual([null, {}])
-        done()
-      })
+      const pullSpy = sinon.spy(() => {})
 
       // create a model with mocked cache "retrieve" function
       const model = createModel({ ProviderModel: providerMock.Model, koop: koopMock }, {
@@ -34,50 +66,61 @@ describe('Tests for create-model', function () {
         }
       })
 
-      model.pull({ url: 'domain/test-provider', params: {}, query: {} }, pullSpy)
-
-
+      await model.pull({ url: 'domain/test-provider', params: {}, query: {} }, pullSpy)
+      pullSpy.should.be.calledOnce()
+      pullSpy.firstCall.args.length.should.equal(2)
+      pullSpy.firstCall.args.should.deepEqual([null, {}])
+      retrieveSpy.should.be.calledOnce()
+      retrieveSpy.firstCall.args.length.should.equal(3)
+      retrieveSpy.firstCall.args[0].should.equal('test-provider::data')
+      retrieveSpy.firstCall.args[1].should.be.an.Object().and.be.empty()
+      retrieveSpy.firstCall.args[2].should.be.an.Function()
     })
 
-    it('should create cache-key as provider name and concenated url params', () => {
+    it('should create cache-key as provider name and concenated url params', async () => {
       const retrieveSpy = sinon.spy(function (key, queryParams, callback) {
         callback(null, {})
       })
-      const pullSpy = sinon.spy()
+      const pullSpy = sinon.spy(() => {})
 
       // create a model with mocked cache "retrieve" function
       const model = createModel({ ProviderModel: providerMock.Model, koop: koopMock }, {
         cache: {
-          retrieve: retrieveSpy
+          retrieve: retrieveSpy,
+          upsert: () => {}
         }
       })
-      model.pull({ url: 'domain/test-provider', params: { host: 'host-param', id: 'id-param', layer: 'layer-param' }, query: {} }, pullSpy)
 
+      await model.pull({ url: 'domain/test-provider', params: { host: 'host-param', id: 'id-param', layer: 'layer-param' }, query: {} }, pullSpy)
+
+      pullSpy.should.be.calledOnce()
+      pullSpy.firstCall.args.length.should.equal(2)
+      should.not.exist(pullSpy.firstCall.args[0])
+      pullSpy.firstCall.args[1].should.be.an.Object().and.be.empty()
       retrieveSpy.should.be.calledOnce()
       retrieveSpy.firstCall.args.length.should.equal(3)
       retrieveSpy.firstCall.args[0].should.equal('test-provider::host-param::id-param::layer-param::data')
       retrieveSpy.firstCall.args[1].should.be.an.Object().and.be.empty()
       retrieveSpy.firstCall.args[2].should.be.an.Function()
-      pullSpy.should.be.calledOnce()
-      pullSpy.firstCall.args.length.should.equal(2)
-      should.not.exist(pullSpy.firstCall.args[0])
-      pullSpy.firstCall.args[1].should.be.an.Object().and.be.empty()
     })
 
-    it('should create cache-key from Model defined createKey function', () => {
+    it('should create cache-key from Model defined createKey function', async () => {
       const retrieveSpy = sinon.spy(function (key, queryParams, callback) {
         callback(null, {})
       })
       const pullSpy = sinon.spy()
 
+      class Model extends providerMock.Model {
+        createKey () { return 'custom-key' }
+      }
       // create a model with mocked cache "retrieve" function
-      const model = createModel({ ProviderModel: providerMock.Model, koop: koopMock }, {
+      const model = createModel({ ProviderModel: Model, koop: koopMock }, {
         cache: {
-          retrieve: retrieveSpy
+          retrieve: retrieveSpy,
+          upsert: () => {}
         }
       })
-      model.createKey = function () { return 'custom-key' }
-      model.pull({ url: 'domain/test-provider', query: {} }, pullSpy)
+      await model.pull({ url: 'domain/test-provider', query: {} }, pullSpy)
       retrieveSpy.should.be.calledOnce()
       retrieveSpy.firstCall.args.length.should.equal(3)
       retrieveSpy.firstCall.args[0].should.equal('custom-key::data')
@@ -101,7 +144,12 @@ describe('Tests for create-model', function () {
     }
 
     it('should attach auth methods when auth plugin is registered with Koop', () => {
-      const model = createModel({ ProviderModel: providerMock.Model, namespace: 'test-provider', koop: koopMock })
+      const model = createModel({ ProviderModel: providerMock.Model, namespace: 'test-provider', koop: koopMock }, {
+        cache: {
+          retrieve: () => {},
+          upsert: () => {}
+        }
+      })
       model.should.have.property('authorize').and.be.a.Function()
       model.should.have.property('authenticate').and.be.a.Function()
       model.should.have.property('authenticationSpecification').and.deepEqual({ provider: 'test-provider' })
@@ -109,24 +157,32 @@ describe('Tests for create-model', function () {
   })
 
   describe('transformation functions', function () {
-    it('before function should modify request object', () => {
+    it('before function should modify request object', async () => {
       let beforeReq
-      const beforeSpy = sinon.spy(function (req, next) {
+      const beforeSpy = sinon.spy((req, beforeCallback) => {
         // capture args because the req gets mutated
         beforeReq = _.cloneDeep(req)
         req.query.hello = 'world'
-        next()
+        beforeCallback()
       })
+
       const getDataSpy = sinon.spy(function (req, callback) {
         callback(null, { metadata: {} })
       })
+      class Model extends providerMock.Model {}
+      Model.prototype.getData = getDataSpy
 
-      const model = createModel({ ProviderModel: providerMock.Model, koop: koopMock }, {
-        cache: { retrieve: (key, query, callback) => { callback(new Error('no cache')) } }
+      const model = createModel({ ProviderModel: Model, koop: koopMock }, {
+        cache: {
+          retrieve: (key, query, callback) => {
+            callback(new Error('no cache'))
+          },
+          upsert: () => {}
+        },
+        before: beforeSpy
       })
-      model.before = beforeSpy
-      model.getData = getDataSpy
-      model.pull({ url: 'domain/test-provider', params: {}, query: {} }, function (err, data) {})
+
+      await model.pull({ url: 'domain/test-provider', params: {}, query: {} }, function (err, data) {})
       beforeSpy.should.be.calledOnce()
       beforeSpy.firstCall.args.length.should.equal(2)
       beforeSpy.firstCall.args[0].should.be.an.Object()
@@ -139,7 +195,7 @@ describe('Tests for create-model', function () {
       getDataSpy.firstCall.args[1].should.be.a.Function()
     })
 
-    it('after function should modify request and data object', () => {
+    it('after function should modify request and data object', async () => {
       let getDataArgs
       let afterSpyArgs
       const getDataSpy = sinon.spy(function (req, callback) {
@@ -147,6 +203,10 @@ describe('Tests for create-model', function () {
         getDataArgs = _.cloneDeep(arguments)
         callback(null, { metadata: {} })
       })
+
+      class Model extends providerMock.Model {}
+      Model.prototype.getData = getDataSpy
+
       const afterSpy = sinon.spy(function (req, data, callback) {
         // capture args because the req and data get mutated
         afterSpyArgs = _.cloneDeep(arguments)
@@ -155,13 +215,17 @@ describe('Tests for create-model', function () {
         callback(null, data)
       })
       const pullCallbackSpy = sinon.spy(function (err, data) {})
-      const model = createModel({ ProviderModel: providerMock.Model, koop: koopMock }, {
-        cache: { retrieve: (key, query, callback) => { callback(new Error('no cache')) } }
+      const model = createModel({ ProviderModel: Model, koop: koopMock }, {
+        cache: {
+          retrieve: (key, query, callback) => {
+            callback(new Error('no cache'))
+          },
+          upsert: () => {}
+        },
+        after: afterSpy
       })
-      model.getData = getDataSpy
-      model.after = afterSpy
-      model.pull({ url: 'domain/test-provider', params: {}, query: {} }, pullCallbackSpy)
 
+      await model.pull({ url: 'domain/test-provider', params: {}, query: {} }, pullCallbackSpy)
       getDataSpy.should.be.calledOnce()
       getDataSpy.firstCall.args.length.should.equal(2)
       getDataArgs[0].should.deepEqual({ url: 'domain/test-provider', params: {}, query: {} })
@@ -197,7 +261,8 @@ describe('Tests for create-model', function () {
       // create a model with mocked cache "retrieve" function
       const model = createModel({ ProviderModel: providerMock.Model, koop: koopMock }, {
         cache: {
-          retrieve: retrieveSpy
+          retrieve: retrieveSpy,
+          upsert: () => {}
         }
       })
 
@@ -223,7 +288,8 @@ describe('Tests for create-model', function () {
       // create a model with mocked cache "retrieve" function
       const model = createModel({ ProviderModel: providerMock.Model, koop: koopMock }, {
         cache: {
-          retrieve: retrieveSpy
+          retrieve: retrieveSpy,
+          upsert: () => {}
         }
       })
 
@@ -253,7 +319,8 @@ describe('Tests for create-model', function () {
       // create a model with mocked cache "retrieve" function
       const model = createModel({ ProviderModel: providerMock.Model, koop: koopMock }, {
         cache: {
-          retrieve: retrieveSpy
+          retrieve: retrieveSpy,
+          upsert: () => {}
         }
       })
 
@@ -285,7 +352,8 @@ describe('Tests for create-model', function () {
       // create a model with mocked cache "retrieve" function
       const model = createModel({ ProviderModel: providerMock.Model, koop: koopMock }, {
         cache: {
-          retrieve: retrieveSpy
+          retrieve: retrieveSpy,
+          upsert: () => {}
         }
       })
 
@@ -309,7 +377,8 @@ describe('Tests for create-model', function () {
       // create a model with mocked cache "retrieve" function
       const model = createModel({ ProviderModel: providerMock.Model, koop: koopMock }, {
         cache: {
-          retrieve: retrieveSpy
+          retrieve: retrieveSpy,
+          upsert: () => {}
         }
       })
 
@@ -341,7 +410,8 @@ describe('Tests for create-model', function () {
       // create a model with mocked cache "retrieve" function
       const model = createModel({ ProviderModel: providerMock.Model, koop: koopMock }, {
         cache: {
-          retrieve: retrieveSpy
+          retrieve: retrieveSpy,
+          upsert: () => {}
         }
       })
 

--- a/test/provider-registration/index.spec.js
+++ b/test/provider-registration/index.spec.js
@@ -14,7 +14,11 @@ describe('Tests for Provider', function () {
     })
     const koopMock = {
       server: serverSpy,
-      outputs: [mockOutputPlugin]
+      outputs: [mockOutputPlugin],
+      cache: {
+        retrieve: () => {},
+        upsert: () => {}
+      }
     }
     const providerRegistration = ProviderRegistration.create({ koop: koopMock, provider: { ...mockProviderPlugin, hosts: true } })
     providerRegistration.should.be.instanceOf(ProviderRegistration)

--- a/test/provider-registration/provider-output-route.spec.js
+++ b/test/provider-registration/provider-output-route.spec.js
@@ -11,7 +11,16 @@ describe('Tests for ProviderOutputRoute', function () {
       get: () => {},
       post: () => {}
     })
-    const provider = new ProviderRegistration({ provider: mockProviderPlugin, koop: { outputs: [mockOutputPlugin] } })
+    const provider = new ProviderRegistration({
+      provider: mockProviderPlugin,
+      koop: {
+        outputs: [mockOutputPlugin],
+        cache: {
+          retrieve: () => {},
+          upsert: () => {}
+        }
+      }
+    })
     const providerOutputRoute = ProviderOutputRoute.create({
       ...provider,
       ...provider.outputs[0].routes[0],

--- a/test/provider-registration/provider-route.spec.js
+++ b/test/provider-registration/provider-route.spec.js
@@ -9,7 +9,16 @@ describe('Tests for ProviderRoute', function () {
     const serverSpy = sinon.spy({
       get: () => {}
     })
-    const provider = new Provider({ provider: mockProviderPlugin, koop: { outputs: [] } })
+    const provider = new Provider({
+      provider: mockProviderPlugin,
+      koop: {
+        outputs: [],
+        cache: {
+          retrieve: () => {},
+          upsert: () => {}
+        }
+      }
+    })
     const providerRoute = ProviderRoute.create({
       ...provider,
       ...provider.routes[0],


### PR DESCRIPTION
This PR refactors the Model's "pull" method as an async function so that the nested callback are eliminated.