### PR TITLE
Add streaming support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
+### Added
+* Support for NodeJS streams as a data interchange format between provider and output plugins ([#141](https://github.com/koopjs/koop-core/issues/141))
 ### Fixed
 * Inconsistent cache key when a `createKey` function is provided ([#136](https://github.com/koopjs/koop-core/issues/136))
 

--- a/lib/provider-registration/create-model.js
+++ b/lib/provider-registration/create-model.js
@@ -77,6 +77,16 @@ module.exports = function createModel ({ ProviderModel, koop, namespace }, optio
         }
       })
     }
+
+    async pullStream (req, callback) {
+      if (this.getStream) {
+        await this.before(req)
+        const providerStream = await this.getStream(req)
+        callback(null, providerStream)
+      } else {
+        callback(new Error('getStream() function is not implemented in the provider.'))
+      }
+    }
   }
 
   // Add auth methods if auth plugin registered with Koop

--- a/lib/provider-registration/create-model.js
+++ b/lib/provider-registration/create-model.js
@@ -80,9 +80,13 @@ module.exports = function createModel ({ ProviderModel, koop, namespace }, optio
 
     async pullStream (req, callback) {
       if (this.getStream) {
-        await this.before(req)
-        const providerStream = await this.getStream(req)
-        callback(null, providerStream)
+        try {
+          await this.before(req)
+          const providerStream = await this.getStream(req)
+          callback(null, providerStream)
+        } catch (err) {
+          callback(err)
+        }
       } else {
         callback(new Error('getStream() function is not implemented in the provider.'))
       }

--- a/lib/provider-registration/create-model.js
+++ b/lib/provider-registration/create-model.js
@@ -78,17 +78,16 @@ module.exports = function createModel ({ ProviderModel, koop, namespace }, optio
       })
     }
 
-    async pullStream (req, callback) {
+    async pullStream (req) {
       if (this.getStream) {
-        try {
-          await this.before(req)
-          const providerStream = await this.getStream(req)
-          callback(null, providerStream)
-        } catch (err) {
-          callback(err)
-        }
+        await this.before(req)
+        const providerStream = await this.getStream(req)
+        providerStream.on('end', () => {
+          this.after(req)
+        })
+        return providerStream
       } else {
-        callback(new Error('getStream() function is not implemented in the provider.'))
+        throw new Error('getStream() function is not implemented in the provider.')
       }
     }
   }


### PR DESCRIPTION
Adds support for provider plugins using NodeJS streams instead of JSON to pass data to the output plugins (issue https://github.com/koopjs/koop-core/issues/141).

Caching doesn't make sense in this case, so the `pullStream` method is quite simple.