### PR TITLE
Remove "after" option for pullStream.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
+### Fixed
+* improper use of `after` in pullStream
 
 ## [4.2.0] - 2021-06-19
 ### Added

--- a/lib/provider-registration/create-model.js
+++ b/lib/provider-registration/create-model.js
@@ -82,9 +82,6 @@ module.exports = function createModel ({ ProviderModel, koop, namespace }, optio
       if (this.getStream) {
         await this.before(req)
         const providerStream = await this.getStream(req)
-        providerStream.on('end', () => {
-          this.after(req)
-        })
         return providerStream
       } else {
         throw new Error('getStream() function is not implemented in the provider.')

--- a/test/provider-registration/create-model.spec.js
+++ b/test/provider-registration/create-model.spec.js
@@ -567,29 +567,6 @@ describe('Tests for create-model', function () {
       getStreamSpy.should.be.calledOnce()
     })
 
-    it.only('should invoke "after" when stream is finished', async function () {
-      const readable = new Readable({ read () {} })
-      getStreamSpy.resolves(readable)
-
-      const afterSpy = sinon.stub().callsFake((_, _2, cb) => {
-        cb()
-      })
-
-      const model = createModel({ ProviderModel: providerMock.Model, koop: koopMock })
-
-      const stream = await model.pullStream({ some: 'options' })
-
-      afterSpy.should.not.be.called()
-
-      stream.push('foo')
-      stream.push('bar')
-      stream.push(null)
-
-      stream.on('end', () => {
-        afterSpy.should.be.calledOnce()
-      })
-    })
-
     it('should reject if the getStream() function is not implemented', async function () {
       providerMock.Model.prototype.getStream = undefined // no getStream function
 


### PR DESCRIPTION
Does not really make sense to have an `after` transform function in the case of a stream, as it it used to transform the geojson while in memory.  As it was not working (missing an await), this is not actually a breaking change.