### PR TITLE
changed middleware to prefer query token

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,7 +54,11 @@ function initServer (config) {
     .disable('x-powered-by')
     // TODO this should just live inside featureserver
     .use((req, res, next) => {
-    // request parameters can come from query url or POST body
+      // request parameters can come from query url or POST body
+      // prefer token to from query to prevent issues with agol proxies
+      if (req.query.token && req.body.token) {
+        delete req.body.token;
+      }
       req.query = _.extend(req.query || {}, req.body || {})
       next()
     })


### PR DESCRIPTION
This was done to prevent issues with the proxies AGOL use.  During item creation the correct token will be sent in the url query but not in the body.  The middleware that appends all body parameters to the query then overwrites the correct token with the incorrect token preventing the add item process from working correctly.