### PR TITLE
Add disable cors option to allow overriding

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,7 +59,9 @@ function initServer (config) {
     // for demos and preview maps in providers
     .set('view engine', 'ejs')
     .use(express.static(path.join(__dirname, '/public')))
-    .use(cors())
+
+  // Use CORS unless explicitly disable in the config
+  if (!config.disableCors) app.use(cors())
 
   // Use compression unless explicitly disable in the config
   if (!config.disableCompression) app.use(compression())


### PR DESCRIPTION
Currently, it is not possible to override CORS option that is set in Koop core (see details; https://github.com/koopjs/koop/issues/354), this small change will allow developers to override CORS options.
